### PR TITLE
[Feat] Swagger 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,30 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+	// SQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/ctrlS/totori/controller/AuthController.java
+++ b/src/main/java/ctrlS/totori/controller/AuthController.java
@@ -1,6 +1,8 @@
 package ctrlS.totori.controller;
 
+import ctrlS.totori.dto.auth.LoginRequest;
 import ctrlS.totori.dto.auth.SignUpRequest;
+import ctrlS.totori.dto.auth.TokenResponse;
 import ctrlS.totori.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,5 +22,11 @@ public class AuthController {
     public ResponseEntity<String> signUp(@Valid @RequestBody SignUpRequest request) {
         authService.signUp(request);
         return ResponseEntity.ok("회원가입이 완료되었습니다.");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        TokenResponse tokenResponse = authService.login(request);
+        return ResponseEntity.ok(tokenResponse);
     }
 }

--- a/src/main/java/ctrlS/totori/controller/AuthController.java
+++ b/src/main/java/ctrlS/totori/controller/AuthController.java
@@ -1,0 +1,24 @@
+package ctrlS.totori.controller;
+
+import ctrlS.totori.dto.auth.SignUpRequest;
+import ctrlS.totori.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signUp(@Valid @RequestBody SignUpRequest request) {
+        authService.signUp(request);
+        return ResponseEntity.ok("회원가입이 완료되었습니다.");
+    }
+}

--- a/src/main/java/ctrlS/totori/domain/common/BaseTimeEntity.java
+++ b/src/main/java/ctrlS/totori/domain/common/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package ctrlS.totori.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedBy
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/ctrlS/totori/domain/member/LoginType.java
+++ b/src/main/java/ctrlS/totori/domain/member/LoginType.java
@@ -1,0 +1,5 @@
+package ctrlS.totori.domain.member;
+
+public enum LoginType {
+    NATIVE, KAKAO
+}

--- a/src/main/java/ctrlS/totori/domain/member/Member.java
+++ b/src/main/java/ctrlS/totori/domain/member/Member.java
@@ -1,0 +1,49 @@
+package ctrlS.totori.domain.member;
+
+import ctrlS.totori.domain.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String loginId;
+
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    private LocalDate birthDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType;
+
+    private Integer level;
+
+    @Builder
+    public Member(String loginId, String password, String name, LocalDate birthDate, Role role, LoginType loginType, Integer level) {
+        this.loginId = loginId;
+        this.password = password;
+        this.name = name;
+        this.birthDate = birthDate;
+        this.role = role;
+        this.loginType = loginType;
+        this.level = level;
+    }
+}

--- a/src/main/java/ctrlS/totori/domain/member/MemberRepository.java
+++ b/src/main/java/ctrlS/totori/domain/member/MemberRepository.java
@@ -1,0 +1,13 @@
+package ctrlS.totori.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    // 로그인 시 아이디로 회원 찾기
+    Optional<Member> findByLoginId(String loginId);
+
+    // 중복 가입 방지
+    boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/ctrlS/totori/domain/member/Role.java
+++ b/src/main/java/ctrlS/totori/domain/member/Role.java
@@ -1,0 +1,5 @@
+package ctrlS.totori.domain.member;
+
+public enum Role {
+    PARENT, CHILD
+}

--- a/src/main/java/ctrlS/totori/domain/parentchild/ParentChild.java
+++ b/src/main/java/ctrlS/totori/domain/parentchild/ParentChild.java
@@ -1,0 +1,33 @@
+package ctrlS.totori.domain.parentchild;
+
+import ctrlS.totori.domain.common.BaseTimeEntity;
+import ctrlS.totori.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"parent_id", "child_id"})})
+public class ParentChild extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id", nullable = false)
+    private Member parent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Member child;
+
+    @Builder
+    public ParentChild(Member parent, Member child) {
+        this.parent = parent;
+        this.child = child;
+    }
+}

--- a/src/main/java/ctrlS/totori/domain/parentchild/ParentChildRepository.java
+++ b/src/main/java/ctrlS/totori/domain/parentchild/ParentChildRepository.java
@@ -1,0 +1,6 @@
+package ctrlS.totori.domain.parentchild;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParentChildRepository extends JpaRepository<ParentChild, Long> {
+}

--- a/src/main/java/ctrlS/totori/dto/auth/LoginRequest.java
+++ b/src/main/java/ctrlS/totori/dto/auth/LoginRequest.java
@@ -1,0 +1,15 @@
+package ctrlS.totori.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String loginId;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/ctrlS/totori/dto/auth/SignUpRequest.java
+++ b/src/main/java/ctrlS/totori/dto/auth/SignUpRequest.java
@@ -1,0 +1,28 @@
+package ctrlS.totori.dto.auth;
+
+import ctrlS.totori.domain.member.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class SignUpRequest {
+    @NotBlank(message = "아이디는 필수입니다.")
+    private String loginId;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    private String name;
+
+    @NotNull(message = "생년월일은 필수입니다.")
+    private LocalDate birthDate;
+
+    @NotNull(message = "역할(PARENT 또는 CHILD)을 선택해주세요.")
+    private Role role;
+}

--- a/src/main/java/ctrlS/totori/dto/auth/TokenResponse.java
+++ b/src/main/java/ctrlS/totori/dto/auth/TokenResponse.java
@@ -1,0 +1,11 @@
+package ctrlS.totori.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+    private String token;
+    private String role;
+}

--- a/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package ctrlS.totori.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/parent/**").hasRole("PARENT")
+                        .requestMatchers("/api/child/**").hasRole("CHILD")
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/parent/**").hasRole("PARENT")
                         .requestMatchers("/api/child/**").hasRole("CHILD")
                         .anyRequest().authenticated()

--- a/src/main/java/ctrlS/totori/global/config/SwaggerConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package ctrlS.totori.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "토토리 API 명세서", version = "v1", description = "난독 아동의 소리 내어 읽기 개선을 위한, 음성 인식 기반 읽기 오류 패턴 분석과 맞춤형 동화책 생성을 활용한 학습 서비스"),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class SwaggerConfig {
+}

--- a/src/main/java/ctrlS/totori/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/ctrlS/totori/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,61 @@
+package ctrlS.totori.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+    private final long validTime = 30 * 60 * 1000L; // 30분
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // 토큰 생성
+    public String createToken(String userPk, String role) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + validTime);
+
+        return Jwts.builder()
+                .subject(userPk) // 토큰 주인(회원 ID)
+                .claim("role", role)
+                .issuedAt(now) // 발행 시간
+                .expiration(expiration) // 만료 시간
+                .signWith(key) // 키로 암호화
+                .compact();
+    }
+
+    // 토큰에서 회원 정보 추출
+    public String getUserPk(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    // 토큰 유효성 + 만료일자 확인
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/ctrlS/totori/service/AuthService.java
+++ b/src/main/java/ctrlS/totori/service/AuthService.java
@@ -1,0 +1,41 @@
+package ctrlS.totori.service;
+
+import ctrlS.totori.domain.member.LoginType;
+import ctrlS.totori.domain.member.Member;
+import ctrlS.totori.domain.member.MemberRepository;
+import ctrlS.totori.dto.auth.SignUpRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public Long signUp(SignUpRequest request) {
+        // 아이디 중복 검사
+        if (memberRepository.existsByLoginId(request.getLoginId())) {
+            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+        }
+
+        // 비밀번호 암호화
+        String encodePassword = passwordEncoder.encode(request.getPassword());
+
+        // Entity 생성
+        Member member = Member.builder()
+                .loginId(request.getLoginId())
+                .password(encodePassword)
+                .name(request.getName())
+                .birthDate(request.getBirthDate())
+                .role(request.getRole())
+                .loginType(LoginType.NATIVE)
+                .build();
+
+        // DB에 저장하고 회원 고유 Id 반환
+        return memberRepository.save(member).getId();
+    }
+}

--- a/src/main/java/ctrlS/totori/service/AuthService.java
+++ b/src/main/java/ctrlS/totori/service/AuthService.java
@@ -3,7 +3,10 @@ package ctrlS.totori.service;
 import ctrlS.totori.domain.member.LoginType;
 import ctrlS.totori.domain.member.Member;
 import ctrlS.totori.domain.member.MemberRepository;
+import ctrlS.totori.dto.auth.LoginRequest;
 import ctrlS.totori.dto.auth.SignUpRequest;
+import ctrlS.totori.dto.auth.TokenResponse;
+import ctrlS.totori.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public Long signUp(SignUpRequest request) {
@@ -38,4 +42,23 @@ public class AuthService {
         // DB에 저장하고 회원 고유 Id 반환
         return memberRepository.save(member).getId();
     }
+
+    @Transactional(readOnly = true)
+    public TokenResponse login(LoginRequest request) {
+        // DB에서 아이디로 회원 찾기
+        Member member = memberRepository.findByLoginId(request.getLoginId())
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 아이디입니다."));
+
+        // 비밀번호 확인
+        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 비밀번호까지 맞으면 JWT 토큰 생성
+        String token = jwtTokenProvider.createToken(String.valueOf(member.getId()), member.getRole().name());
+
+        // 토큰과 권한 정보 반환
+        return new TokenResponse(token, member.getRole().name());
+    }
+
 }


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- API 명세 자동화를 위해 Swagger 설정 추가

## 📍 변경 사항
- Create: SwaggerConfig
- Update: SecurityConfig
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
- 문제: SwaggerConfig 작성 후 UI 실행하려고 했더니 '이 페이지를 볼 수 있는 권한이 없습니다. HTTP ERROR 403 ' 에러가 발생했습니다.
- 해결: SecurityConfig에서 "/swagger-ui/**", "/v3/api-docs/**/" 권한 추가해서 해결했습니다. 


## 🔍 참고 사항
http://localhost:8080/swagger-ui/index.html 에 접속하면 아래 화면을 확인할 수 있습니다.

<img width="742" height="809" alt="스크린샷 2026-02-16 오후 3 52 37" src="https://github.com/user-attachments/assets/b6b7fd64-715c-4630-a477-469d60e4be7d" />


## ✨ 관련 이슈
- closes #7 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [ ] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
