### PR TITLE
[Feat] 카카오 로그인 기능 및 온보딩 구조 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/ctrlS/totori/auth/controller/AuthController.java
+++ b/src/main/java/ctrlS/totori/auth/controller/AuthController.java
@@ -1,9 +1,9 @@
-package ctrlS.totori.controller;
+package ctrlS.totori.auth.controller;
 
-import ctrlS.totori.dto.auth.LoginRequest;
-import ctrlS.totori.dto.auth.SignUpRequest;
-import ctrlS.totori.dto.auth.TokenResponse;
-import ctrlS.totori.service.AuthService;
+import ctrlS.totori.auth.dto.LoginRequest;
+import ctrlS.totori.auth.dto.SignUpRequest;
+import ctrlS.totori.auth.dto.TokenResponse;
+import ctrlS.totori.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/ctrlS/totori/auth/controller/AuthController.java
+++ b/src/main/java/ctrlS/totori/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package ctrlS.totori.auth.controller;
 
+import ctrlS.totori.auth.dto.CompleteProfileRequest;
 import ctrlS.totori.auth.dto.LoginRequest;
 import ctrlS.totori.auth.dto.SignUpRequest;
 import ctrlS.totori.auth.dto.TokenResponse;
@@ -7,10 +8,8 @@ import ctrlS.totori.auth.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -28,5 +27,12 @@ public class AuthController {
     public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
         TokenResponse tokenResponse = authService.login(request);
         return ResponseEntity.ok(tokenResponse);
+    }
+
+    @PostMapping("/oauth/complete")
+    public ResponseEntity<Void> completeProfile(@RequestBody CompleteProfileRequest request, Authentication authentication) {
+        Long memberId = Long.valueOf(authentication.getName());
+        authService.completeProfile(memberId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/ctrlS/totori/auth/controller/TestController.java
+++ b/src/main/java/ctrlS/totori/auth/controller/TestController.java
@@ -1,0 +1,47 @@
+package ctrlS.totori.auth.controller;
+
+import ctrlS.totori.global.security.JwtTokenProvider;
+import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.entity.Role;
+import ctrlS.totori.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    // 카카오 로그인 임시 확인 테스트
+    // todo: 프론트 화면 구현 시 삭제
+    @GetMapping("/login/success")
+    public String loginSuccess(@RequestParam("token") String token,
+                               @RequestParam(value = "profileCompleted", required = false, defaultValue = "false") boolean profileCompleted) {
+        return "token=" + token + "\n" + "profileCompleted=" + profileCompleted;
+    }
+
+    // 카카오 처음 시작 시 온보딩 테스트
+    @PostMapping("/test/onboarding")
+    @Transactional
+    public ResponseEntity<String> completeOnboarding(
+            @RequestParam String token,
+            @RequestParam Role role,
+            @RequestParam String name,
+            @RequestParam String birthDate
+    ) {
+        String memberIdStr = jwtTokenProvider.getUserPk(token); // 너희 메서드명에 맞게
+        Long memberId = Long.valueOf(memberIdStr);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        member.completeProfile(role, name, LocalDate.parse(birthDate));
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/src/main/java/ctrlS/totori/auth/dto/CompleteProfileRequest.java
+++ b/src/main/java/ctrlS/totori/auth/dto/CompleteProfileRequest.java
@@ -1,0 +1,9 @@
+package ctrlS.totori.auth.dto;
+
+import ctrlS.totori.member.entity.Role;
+
+import java.time.LocalDate;
+
+public record CompleteProfileRequest(Role role, String name, LocalDate birthDate) {
+
+}

--- a/src/main/java/ctrlS/totori/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/ctrlS/totori/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,17 @@
+package ctrlS.totori.auth.dto;
+
+import java.util.Map;
+
+public record KakaoUserInfo(Map<String, Object> attributes) {
+
+    // 카카오 ID
+    public String getId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    // 닉네임
+    public String getNickname() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        return properties != null ? (String) properties.get("nickname") : null;
+    }
+}

--- a/src/main/java/ctrlS/totori/auth/dto/LoginRequest.java
+++ b/src/main/java/ctrlS/totori/auth/dto/LoginRequest.java
@@ -1,4 +1,4 @@
-package ctrlS.totori.dto.auth;
+package ctrlS.totori.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/src/main/java/ctrlS/totori/auth/dto/SignUpRequest.java
+++ b/src/main/java/ctrlS/totori/auth/dto/SignUpRequest.java
@@ -1,6 +1,6 @@
-package ctrlS.totori.dto.auth;
+package ctrlS.totori.auth.dto;
 
-import ctrlS.totori.domain.member.Role;
+import ctrlS.totori.member.entity.Role;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;

--- a/src/main/java/ctrlS/totori/auth/dto/TokenResponse.java
+++ b/src/main/java/ctrlS/totori/auth/dto/TokenResponse.java
@@ -1,4 +1,4 @@
-package ctrlS.totori.dto.auth;
+package ctrlS.totori.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/ctrlS/totori/auth/service/AuthService.java
+++ b/src/main/java/ctrlS/totori/auth/service/AuthService.java
@@ -1,12 +1,12 @@
-package ctrlS.totori.service;
+package ctrlS.totori.auth.service;
 
-import ctrlS.totori.domain.member.LoginType;
-import ctrlS.totori.domain.member.Member;
-import ctrlS.totori.domain.member.MemberRepository;
-import ctrlS.totori.dto.auth.LoginRequest;
-import ctrlS.totori.dto.auth.SignUpRequest;
-import ctrlS.totori.dto.auth.TokenResponse;
-import ctrlS.totori.global.jwt.JwtTokenProvider;
+import ctrlS.totori.member.entity.LoginType;
+import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.repository.MemberRepository;
+import ctrlS.totori.auth.dto.LoginRequest;
+import ctrlS.totori.auth.dto.SignUpRequest;
+import ctrlS.totori.auth.dto.TokenResponse;
+import ctrlS.totori.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/ctrlS/totori/auth/service/AuthService.java
+++ b/src/main/java/ctrlS/totori/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package ctrlS.totori.auth.service;
 
+import ctrlS.totori.auth.dto.CompleteProfileRequest;
 import ctrlS.totori.member.entity.LoginType;
 import ctrlS.totori.member.entity.Member;
 import ctrlS.totori.member.repository.MemberRepository;
@@ -61,4 +62,10 @@ public class AuthService {
         return new TokenResponse(token, member.getRole().name());
     }
 
+    @Transactional
+    public void completeProfile(Long memberId, CompleteProfileRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+        member.completeProfile(request.role(), request.name(), request.birthDate());
+    }
 }

--- a/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
@@ -53,7 +53,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         memberRepository.save(member);
 
-        // todo: 프론트 화면 구현 시 삭제
+        // todo: 프론트 화면 구현 시 테스트 로그 제거
         log.info("카카오 로그인 성공: {}", loginId);
 
         // 5. Security 세션에 저장할 정보 반환

--- a/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,66 @@
+package ctrlS.totori.auth.service;
+
+import ctrlS.totori.auth.dto.KakaoUserInfo;
+import ctrlS.totori.member.entity.LoginType;
+import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.entity.Role;
+import ctrlS.totori.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 1. 카카오에서 사용자 정보 가져오기
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // 2. 데이터 파싱
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        KakaoUserInfo kakaoInfo = new KakaoUserInfo(attributes);
+
+        // 3. DB에 저장할 ID 생성
+        String loginId = "KAKAO_" + kakaoInfo.getId();
+        String nickname = kakaoInfo.getNickname();
+
+        // 4. 저장(회원이 아닌 경우 임시로 회원 생성)
+        Member member = memberRepository.findByLoginId(loginId)
+                .map(entity -> entity.updateName(nickname))
+                .orElseGet(() -> Member.builder()
+                        .loginId(loginId)
+                        .password(null)
+                        .name(nickname)
+                        .role(null)
+                        .loginType(LoginType.KAKAO)
+                        .build());
+
+        memberRepository.save(member);
+
+        // todo: 프론트 화면 구현 시 삭제
+        log.info("카카오 로그인 성공: {}", loginId);
+
+        // 5. Security 세션에 저장할 정보 반환
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_GUEST")),
+                attributes,
+                "id"
+        );
+    }
+}

--- a/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/test/**").permitAll() // todo: 테스트 끝나면 삭제 요망
                         .requestMatchers("/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/login/success").permitAll()
                         .requestMatchers("/api/auth/oauth/complete").authenticated()
                         .requestMatchers("/api/parent/**").hasRole("PARENT")

--- a/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package ctrlS.totori.global.config;
 
+import ctrlS.totori.auth.service.CustomOAuth2UserService;
+import ctrlS.totori.global.security.oauth.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,7 +15,12 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -25,11 +33,18 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/login/success").permitAll()
+                        .requestMatchers("/api/auth/oauth/complete").authenticated()
                         .requestMatchers("/api/parent/**").hasRole("PARENT")
                         .requestMatchers("/api/child/**").hasRole("CHILD")
                         .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
                 );
+        ;
 
         return http.build();
     }

--- a/src/main/java/ctrlS/totori/global/entity/BaseTimeEntity.java
+++ b/src/main/java/ctrlS/totori/global/entity/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package ctrlS.totori.domain.common;
+package ctrlS.totori.global.entity;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;

--- a/src/main/java/ctrlS/totori/global/security/JwtTokenProvider.java
+++ b/src/main/java/ctrlS/totori/global/security/JwtTokenProvider.java
@@ -1,8 +1,6 @@
-package ctrlS.totori.global.jwt;
+package ctrlS.totori.global.security;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
@@ -41,7 +41,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String accessToken = jwtTokenProvider.createToken(String.valueOf(member.getId()), roleForToken);
 
         // 앱으로 리다이렉트할 주소 만들기(임의로 localhost로 보냄)
-        // todo: 앱으로 리다이렉트할 주소 넣기
+        // todo: 앱 연동 시 실제 서비스 도메인으로 redirect URL 변경
         String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/login/success")
                 .queryParam("token", accessToken)
                 .queryParam("profileCompleted", profileCompleted)

--- a/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,53 @@
+package ctrlS.totori.global.security.oauth;
+
+import ctrlS.totori.global.security.JwtTokenProvider;
+import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.repository.MemberRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        // 로그인된 사용자 정보 꺼내기
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        String loginId = "KAKAO_" + attributes.get("id");
+
+        // DB에서 Role 확인
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("가입된 사용자가 없습니다."));
+        boolean profileCompleted = member.getRole() != null && member.getBirthDate() != null;
+
+        // 가입 전이면 GUEST, 가입 후면 실제 role
+        String roleForToken = profileCompleted ? member.getRole().name() : "GUEST";
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenProvider.createToken(String.valueOf(member.getId()), roleForToken);
+
+        // 앱으로 리다이렉트할 주소 만들기(임의로 localhost로 보냄)
+        // todo: 앱으로 리다이렉트할 주소 넣기
+        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/login/success")
+                .queryParam("token", accessToken)
+                .queryParam("profileCompleted", profileCompleted)
+                .build().toUriString();
+
+        // 리다이렉트 수행
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/ctrlS/totori/member/entity/LoginType.java
+++ b/src/main/java/ctrlS/totori/member/entity/LoginType.java
@@ -1,4 +1,4 @@
-package ctrlS.totori.domain.member;
+package ctrlS.totori.member.entity;
 
 public enum LoginType {
     NATIVE, KAKAO

--- a/src/main/java/ctrlS/totori/member/entity/Member.java
+++ b/src/main/java/ctrlS/totori/member/entity/Member.java
@@ -28,13 +28,16 @@ public class Member extends BaseTimeEntity {
     private LocalDate birthDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Role role;
 
     @Enumerated(EnumType.STRING)
     private LoginType loginType;
 
     private Integer level;
+
+    @Column(nullable = false)
+    private int dotori = 5;
 
     @Builder
     public Member(String loginId, String password, String name, LocalDate birthDate, Role role, LoginType loginType, Integer level) {
@@ -45,5 +48,18 @@ public class Member extends BaseTimeEntity {
         this.role = role;
         this.loginType = loginType;
         this.level = level;
+    }
+
+    // 이름 수정 메서드
+    public Member updateName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    // 카카오 로그인 시 추가 정보 입력 메서드
+    public void completeProfile(Role role, String name, LocalDate birthDate) {
+        this.role = role;
+        this.name = name;
+        this.birthDate = birthDate;
     }
 }

--- a/src/main/java/ctrlS/totori/member/entity/Member.java
+++ b/src/main/java/ctrlS/totori/member/entity/Member.java
@@ -1,6 +1,6 @@
-package ctrlS.totori.domain.member;
+package ctrlS.totori.member.entity;
 
-import ctrlS.totori.domain.common.BaseTimeEntity;
+import ctrlS.totori.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/ctrlS/totori/member/entity/ParentChild.java
+++ b/src/main/java/ctrlS/totori/member/entity/ParentChild.java
@@ -1,4 +1,4 @@
-package ctrlS.totori.relation.entity;
+package ctrlS.totori.member.entity;
 
 import ctrlS.totori.global.entity.BaseTimeEntity;
 import ctrlS.totori.member.entity.Member;

--- a/src/main/java/ctrlS/totori/member/entity/Role.java
+++ b/src/main/java/ctrlS/totori/member/entity/Role.java
@@ -1,4 +1,4 @@
-package ctrlS.totori.domain.member;
+package ctrlS.totori.member.entity;
 
 public enum Role {
     PARENT, CHILD

--- a/src/main/java/ctrlS/totori/member/repository/MemberRepository.java
+++ b/src/main/java/ctrlS/totori/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
-package ctrlS.totori.domain.member;
+package ctrlS.totori.member.repository;
 
+import ctrlS.totori.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/ctrlS/totori/member/repository/ParentChildRepository.java
+++ b/src/main/java/ctrlS/totori/member/repository/ParentChildRepository.java
@@ -1,6 +1,6 @@
-package ctrlS.totori.relation.repository;
+package ctrlS.totori.member.repository;
 
-import ctrlS.totori.relation.entity.ParentChild;
+import ctrlS.totori.member.entity.ParentChild;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParentChildRepository extends JpaRepository<ParentChild, Long> {

--- a/src/main/java/ctrlS/totori/relation/entity/ParentChild.java
+++ b/src/main/java/ctrlS/totori/relation/entity/ParentChild.java
@@ -1,7 +1,7 @@
-package ctrlS.totori.domain.parentchild;
+package ctrlS.totori.relation.entity;
 
-import ctrlS.totori.domain.common.BaseTimeEntity;
-import ctrlS.totori.domain.member.Member;
+import ctrlS.totori.global.entity.BaseTimeEntity;
+import ctrlS.totori.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/ctrlS/totori/relation/repository/ParentChildRepository.java
+++ b/src/main/java/ctrlS/totori/relation/repository/ParentChildRepository.java
@@ -1,5 +1,6 @@
-package ctrlS.totori.domain.parentchild;
+package ctrlS.totori.relation.repository;
 
+import ctrlS.totori.relation.entity.ParentChild;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParentChildRepository extends JpaRepository<ParentChild, Long> {


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 카카오 로그인 및 JWT 발급 로직 구현
- 카카오 로그인 시 사용되는 추가 온보딩(역할, 이름, 생년월일) 구현

## 📍 변경 사항
- Create: CompleteProfileRequest, KakaoUserInfo, CustomOAuth2UserService, OAuth2SuccessHandler
- Update: AuthController, TestController, AuthService, SecurityConfig, Member
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
- 문제: 카카오 로그인 성공했는데 Invalid credentials 이라는 에러 문구가 떴습니다.
해결1: application.yml의 client-secret에 카카오 디벨로퍼스 보안키 입력
해결2: Chrome의 자동입력 방지를 위해 Safari 시크릿 모드 사용
- 문제: 카카오 로그인 성공 후 화면이 무한 루프 되는 현상이 발생했습니다.
해결1: SecurityConfig에 `/login/success` 허용 추가
해결2: `/login/success` 받아줄 TestController 생성
- 문제: 카카오 로그인으로 첫 가입 시 역할, 생년월일을 받을 수 없다는 문제가 있었습니다.
해결: 추가 온보딩(역할, 이름, 생년월일 입력) 구조 구현

## 🔍 참고 사항
TODO:
프론트 화면 구현 후
- TestController와 SecurityConfig의 /test/** 보안 예외 제거
- OAuth2SuccessHandler의 redirect URL을 실제 서비스 도메인으로 변경
- 카카오 로그인 성공 테스트용 로그 제거

브라우저에서 `http://localhost:8080/oauth2/authorization/kakao`로 접속하면 카카오 로그인 화면이 나옵니다.
<img width="688" height="700" alt="스크린샷 2026-02-22 오전 12 40 45" src="https://github.com/user-attachments/assets/9140a82f-3d4d-4d4e-93a0-535d0ebb9b9c" />

처음 시작하는 경우에는 카카오 로그인 성공 시
`token={token}
profileCompleted=false`
가 화면에 나타납니다.

온보딩은 Postman에서 아래와 같이 진행할 수 있습니다.
<img width="660" height="672" alt="스크린샷 2026-02-22 오전 12 44 30" src="https://github.com/user-attachments/assets/00733220-2c5d-4ef1-9c2b-e2e1221bfc54" />

이후 카카오 로그인 성공 시
`token={token}
profileCompleted=true`
가 화면에 나타납니다.

## ✨ 관련 이슈
- closes #10 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [ ] Refactoring (refactor)
* [ ] Styling (style)
* [x] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
