### PR TITLE
[Docs] Swagger API 어노테이션 추가 및 설정 수정

### DIFF
--- a/src/main/java/ctrlS/totori/auth/controller/AuthController.java
+++ b/src/main/java/ctrlS/totori/auth/controller/AuthController.java
@@ -5,6 +5,12 @@ import ctrlS.totori.auth.dto.SignUpRequest;
 import ctrlS.totori.auth.dto.TokenResponse;
 import ctrlS.totori.auth.service.AuthService;
 import ctrlS.totori.member.entity.Role;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -14,24 +20,40 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
+@Tag(name = "인증 API", description = "회원가입, 로그인, 소셜 로그인 관련 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
 
+    @Operation(summary = "자체 회원가입", description = "역할, 아이디, 비밀번호, 이름을 입력받아 회원가입을 진행합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청값", content = @Content)})
     @PostMapping("/signup")
     public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest request) {
         authService.signUp(request);
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "자체 로그인", description = "아이디와 비밀번호로 로그인하고 JWT 토큰을 발급받습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청값", content = @Content),
+            @ApiResponse(responseCode = "401", description = "아이디 또는 비밀번호 불일치", content = @Content)
+    })
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
         TokenResponse tokenResponse = authService.login(request);
         return ResponseEntity.ok(tokenResponse);
     }
 
+    @Operation(summary = "카카오 로그인", description = "역할을 전달받아 세션에 저장한 뒤 카카오 OAuth2 로그인 페이지로 리다이렉트합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "카카오 로그인 페이지로 리다이렉트"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청값", content = @Content)
+    })
     @GetMapping("/social/kakao")
     public void startKakaoLogin(
             @RequestParam Role role,

--- a/src/main/java/ctrlS/totori/global/config/SwaggerConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/SwaggerConfig.java
@@ -1,22 +1,38 @@
 package ctrlS.totori.global.config;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@OpenAPIDefinition(
-        info = @Info(title = "토토리 API 명세서", version = "v1", description = "난독 아동의 소리 내어 읽기 개선을 위한, 음성 인식 기반 읽기 오류 패턴 분석과 맞춤형 동화책 생성을 활용한 학습 서비스"),
-        security = @SecurityRequirement(name = "bearerAuth")
-)
-@SecurityScheme(
-        name = "bearerAuth",
-        type = SecuritySchemeType.HTTP,
-        scheme = "bearer",
-        bearerFormat = "JWT"
-)
 public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("토토리(Totori) API 명세서")
+                .description("난독 아동을 위한 음성 인식 기반 동화책 서비스 백엔드 API (아동 파트 중심)")
+                .version("v1.0.0");
+
+        String jwtSchemeName = "jwtAuth";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name("Authorization")
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("http://localhost:8080"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+
+    }
 }

--- a/src/main/java/ctrlS/totori/member/controller/ConnectController.java
+++ b/src/main/java/ctrlS/totori/member/controller/ConnectController.java
@@ -3,12 +3,6 @@ package ctrlS.totori.member.controller;
 import ctrlS.totori.member.dto.ConnectCodeResponse;
 import ctrlS.totori.member.dto.ConnectRequest;
 import ctrlS.totori.member.service.ConnectService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,18 +11,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "연결 API", description = "아동-보호자 계정 연결 API")
+import java.util.HashMap;
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api/connect")
 @RequiredArgsConstructor
 public class ConnectController {
     private final ConnectService connectService;
 
-    @Operation(summary = "연결 코드 생성 (아동용)", description = "아동이 보호자와 연결하기 위한 5자리 난수 코드를 생성합니다. (유효시간 10분)")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "연결 코드 생성 성공", content = @Content(schema = @Schema(implementation = ConnectCodeResponse.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청값", content = @Content)
-    })
     @PostMapping("/code")
     public ResponseEntity<ConnectCodeResponse> createCode(@AuthenticationPrincipal Long memberId) {
         String code = connectService.createConnectCode(memberId);
@@ -36,11 +27,6 @@ public class ConnectController {
         return ResponseEntity.ok(new ConnectCodeResponse(code, 600));
     }
 
-    @Operation(summary = "아동-보호자 계정 연결")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "계정 연결 성공", content = @Content(schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청값 또는 유효하지 않은 연결 코드", content = @Content)
-    })
     @PostMapping
     public ResponseEntity<String> linkChild(
             @AuthenticationPrincipal Long memberId,

--- a/src/main/java/ctrlS/totori/member/controller/ConnectController.java
+++ b/src/main/java/ctrlS/totori/member/controller/ConnectController.java
@@ -3,6 +3,12 @@ package ctrlS.totori.member.controller;
 import ctrlS.totori.member.dto.ConnectCodeResponse;
 import ctrlS.totori.member.dto.ConnectRequest;
 import ctrlS.totori.member.service.ConnectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,15 +17,18 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
-import java.util.Map;
-
+@Tag(name = "연결 API", description = "아동-보호자 계정 연결 API")
 @RestController
 @RequestMapping("/api/connect")
 @RequiredArgsConstructor
 public class ConnectController {
     private final ConnectService connectService;
 
+    @Operation(summary = "연결 코드 생성 (아동용)", description = "아동이 보호자와 연결하기 위한 5자리 난수 코드를 생성합니다. (유효시간 10분)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "연결 코드 생성 성공", content = @Content(schema = @Schema(implementation = ConnectCodeResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청값", content = @Content)
+    })
     @PostMapping("/code")
     public ResponseEntity<ConnectCodeResponse> createCode(@AuthenticationPrincipal Long memberId) {
         String code = connectService.createConnectCode(memberId);
@@ -27,6 +36,11 @@ public class ConnectController {
         return ResponseEntity.ok(new ConnectCodeResponse(code, 600));
     }
 
+    @Operation(summary = "아동-보호자 계정 연결")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "계정 연결 성공", content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청값 또는 유효하지 않은 연결 코드", content = @Content)
+    })
     @PostMapping
     public ResponseEntity<String> linkChild(
             @AuthenticationPrincipal Long memberId,


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- Swagger API 문서 가독성을 높이기 위해 Controller에 Swagger 어노테이션 추가
- SwaggerConfig 설정 수정

## 📍 변경 사항
Update: AuthController, ConnectController, SwaggerConfig
  
## 🚧 구현 중 겪은 이슈 및 해결 방법


## 🔍 참고 사항
브라우저에서 `http://localhost:8080/swagger-ui/index.html` 로 접속하면 아래와 같은 화면이 나옵니다.
<img width="721" height="700" alt="스크린샷 2026-03-12 오전 2 28 56" src="https://github.com/user-attachments/assets/1241f9b3-8748-4a76-8337-9edc1cb262f5" />


## ✨ 관련 이슈
- closes #15 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [ ] New Features (feat)
* [ ] Test (test)
* [x] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
