### PR TITLE
[Feat] 커스텀 예외처리 추가

### DIFF
--- a/src/main/java/ctrlS/totori/global/exception/CustomException.java
+++ b/src/main/java/ctrlS/totori/global/exception/CustomException.java
@@ -1,0 +1,10 @@
+package ctrlS.totori.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package ctrlS.totori.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // Default
+    ERROR(400, "요청 처리에 실패했습니다."),
+    UNAUTHORIZED_ACCESS(401, "인증되지 않은 사용자입니다."),
+
+    // auth
+    USER_NOT_FOUND(401, "존재하는 사용자가 없습니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/ctrlS/totori/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ctrlS/totori/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package ctrlS.totori.global.exception;
+
+import ctrlS.totori.global.exception.dto.ErrorDto;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorDto> handleCustomException(CustomException e, HttpServletRequest request) {
+        ErrorDto errorDto = new ErrorDto(
+                LocalDateTime.now().toString(),
+                e.getErrorCode().getStatus(),
+                e.getErrorCode().name(),
+                e.getErrorCode().getMessage(),
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorDto, HttpStatusCode.valueOf(e.getErrorCode().getStatus()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorDto> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
+
+        ErrorDto errorDto = new ErrorDto(
+                LocalDateTime.now().toString(),
+                400,
+                "INVALID_INPUT",
+                errorMessage,
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorDto, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/ctrlS/totori/global/exception/dto/ErrorDto.java
+++ b/src/main/java/ctrlS/totori/global/exception/dto/ErrorDto.java
@@ -1,0 +1,9 @@
+package ctrlS.totori.global.exception.dto;
+
+public record ErrorDto(
+        String timestamp,
+        int status,
+        String errorCode,
+        String message,
+        String path
+) {}


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 커스텀 예외처리 추가

## 📍 변경 사항
- CustomException 추가
- ErrorCode 추가
- GlobalExceptionHandler 추가
- ErroDto 추가

## 🔍 참고 사항
추가하려는 에러를 ErrorCode에 경우를 추가해주고 ex) `USER_NOT_FOUND(401, "존재하는 사용자가 없습니다.")`
```java
throw new CustomException(ErrorCode.USER_NOT_FOUND);
```
이렇게 CustomException으로 throw해서 예외처리해주면 됩니당
<img width="369" height="119" alt="image" src="https://github.com/user-attachments/assets/3b226cf4-de90-43c5-b7cb-5d461111cca3" />


## ✨ 관련 이슈
- closes #30

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [ ] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
