### PR TITLE
[Feat] 동화책 이미지 생성 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+/C:/
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/ctrlS/totori/book/dto/BookGenerateResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/BookGenerateResponse.java
@@ -9,6 +9,7 @@ public record BookGenerateResponse(
         String title,
         int totalPages,
         String coverImagePrompt,
+        String coverImageUrl,
         List<BookPageResponse> pages
 ) {
     public static BookGenerateResponse from(Book book) {
@@ -17,6 +18,7 @@ public record BookGenerateResponse(
                 book.getTitle(),
                 book.getTotalPages(),
                 book.getCoverImagePrompt(),
+                book.getCoverImageUrl(),
                 book.getPages().stream()
                         .map(BookPageResponse::from)
                         .toList()

--- a/src/main/java/ctrlS/totori/book/entity/Book.java
+++ b/src/main/java/ctrlS/totori/book/entity/Book.java
@@ -64,4 +64,8 @@ public class Book extends BaseTimeEntity {
                 .totalPages(response.pages().size())
                 .build();
     }
+
+    public void updateCoverImageUrl(String coverImageUrl) {
+        this.coverImageUrl = coverImageUrl;
+    }
 }

--- a/src/main/java/ctrlS/totori/book/entity/BookPage.java
+++ b/src/main/java/ctrlS/totori/book/entity/BookPage.java
@@ -58,4 +58,8 @@ public class BookPage extends BaseTimeEntity {
                 .imageUrl(null)
                 .build();
     }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class BookService {
     private final FastApiStoryClient fastApiStoryClient;
     private final StableDiffusionService stableDiffusionService;
     private final ImageStorageService imageStorageService;
+    private final PageImageAsyncService pageImageAsyncService;
 
     public BookGenerateResponse generateBook(Long memberId, BookGenerateRequest request) {
         Member member = memberRepository.findById(memberId)
@@ -47,18 +49,24 @@ public class BookService {
         long bookSeed = new Random().nextInt(10000000);
 
         int pageNumber = 1;
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
         for (BookPage page : pages) {
             String prompt = page.getImagePrompt();
 
             byte[] imageBytes = stableDiffusionService.generateImage(prompt, bookSeed);
 
             String fileName = UUID.randomUUID() + "_page_" + pageNumber + ".png";
-            String imageUrl = imageStorageService.uploadImage(imageBytes, fileName);
+            CompletableFuture<Void> future = pageImageAsyncService.generateAndUpload(prompt, bookSeed, fileName)
+                 .thenAccept(imageUrl -> {
+                     page.updateImageUrl(imageUrl);
+                 });
 
-            page.updateImageUrl(imageUrl);
-            pageNumber++;
+         futures.add(future);
         }
 
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
         book.getPages().addAll(pages);
 
         Book savedBook = bookRepository.save(book);

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -28,8 +28,6 @@ public class BookService {
     private final BookRepository bookRepository;
     private final BookReadingRecordRepository bookReadingRecordRepository;
     private final FastApiStoryClient fastApiStoryClient;
-    private final StableDiffusionService stableDiffusionService;
-    private final ImageStorageService imageStorageService;
     private final PageImageAsyncService pageImageAsyncService;
 
     public BookGenerateResponse generateBook(Long memberId, BookGenerateRequest request) {
@@ -48,27 +46,36 @@ public class BookService {
 
         long bookSeed = new Random().nextInt(10000000);
 
-        int pageNumber = 1;
-
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
+        String coverPrompt = book.getCoverImagePrompt();
+        if (coverPrompt != null && !coverPrompt.isBlank()) {
+            String coverFileName = UUID.randomUUID() + "_cover.png";
+            CompletableFuture<Void> coverFuture = pageImageAsyncService.generateAndUpload(coverPrompt, bookSeed, coverFileName)
+                    .thenAccept(imageUrl -> {
+                        book.updateCoverImageUrl(imageUrl);
+                    });
+
+            futures.add(coverFuture);
+        }
+
+        int pageNumber = 1;
         for (BookPage page : pages) {
             String prompt = page.getImagePrompt();
-
-            byte[] imageBytes = stableDiffusionService.generateImage(prompt, bookSeed);
-
             String fileName = UUID.randomUUID() + "_page_" + pageNumber + ".png";
+
             CompletableFuture<Void> future = pageImageAsyncService.generateAndUpload(prompt, bookSeed, fileName)
-                 .thenAccept(imageUrl -> {
-                     page.updateImageUrl(imageUrl);
-                 });
+                    .thenAccept(imageUrl -> {
+                        page.updateImageUrl(imageUrl);
+                    });
 
          futures.add(future);
+         pageNumber++;
         }
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-        book.getPages().addAll(pages);
 
+        book.getPages().addAll(pages);
         Book savedBook = bookRepository.save(book);
 
         return BookGenerateResponse.from(savedBook);

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -16,10 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +27,8 @@ public class BookService {
     private final BookRepository bookRepository;
     private final BookReadingRecordRepository bookReadingRecordRepository;
     private final FastApiStoryClient fastApiStoryClient;
+    private final StableDiffusionService stableDiffusionService;
+    private final ImageStorageService imageStorageService;
 
     public BookGenerateResponse generateBook(Long memberId, BookGenerateRequest request) {
         Member member = memberRepository.findById(memberId)
@@ -44,6 +43,21 @@ public class BookService {
         List<BookPage> pages = fastApiResponse.pages().stream()
                 .map(pageResponse -> BookPage.of(book, pageResponse))
                 .toList();
+
+        long bookSeed = new Random().nextInt(10000000);
+
+        int pageNumber = 1;
+        for (BookPage page : pages) {
+            String prompt = page.getImagePrompt();
+
+            byte[] imageBytes = stableDiffusionService.generateImage(prompt, bookSeed);
+
+            String fileName = UUID.randomUUID() + "_page_" + pageNumber + ".png";
+            String imageUrl = imageStorageService.uploadImage(imageBytes, fileName);
+
+            page.updateImageUrl(imageUrl);
+            pageNumber++;
+        }
 
         book.getPages().addAll(pages);
 

--- a/src/main/java/ctrlS/totori/book/service/ImageStorageService.java
+++ b/src/main/java/ctrlS/totori/book/service/ImageStorageService.java
@@ -1,0 +1,5 @@
+package ctrlS.totori.book.service;
+
+public interface ImageStorageService {
+    String uploadImage(byte[] imageBytes, String fileName);
+}

--- a/src/main/java/ctrlS/totori/book/service/LocalImageStorageService.java
+++ b/src/main/java/ctrlS/totori/book/service/LocalImageStorageService.java
@@ -1,0 +1,29 @@
+package ctrlS.totori.book.service;
+
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+public class LocalImageStorageService implements ImageStorageService {
+    private final String UPLOAD_DIR = "C:/totori/images/";
+
+    @Override
+    public String uploadImage(byte[] imageBytes, String fileName) {
+        try {
+            File directory = new File(UPLOAD_DIR);
+            if (!directory.exists()) {
+                directory.mkdirs();
+            }
+            Path path = Paths.get(UPLOAD_DIR + fileName);
+            Files.write(path, imageBytes);
+
+            return "/images/" + fileName;
+        } catch (Exception e) {
+            throw new RuntimeException("로컬 이미지 저장 실패", e);
+        }
+    }
+}

--- a/src/main/java/ctrlS/totori/book/service/PageImageAsyncService.java
+++ b/src/main/java/ctrlS/totori/book/service/PageImageAsyncService.java
@@ -1,0 +1,22 @@
+package ctrlS.totori.book.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+public class PageImageAsyncService {
+
+    private final StableDiffusionService stableDiffusionService;
+    private final ImageStorageService imageStorageService;
+
+    @Async("imageExecutor")
+    public CompletableFuture<String> generateAndUpload(String prompt, Long bookSeed, String fileName) {
+        byte[] imageBytes = stableDiffusionService.generateImage(prompt, bookSeed);
+        String imageUrl = imageStorageService.uploadImage(imageBytes, fileName);
+        return CompletableFuture.completedFuture(imageUrl);
+    }
+}

--- a/src/main/java/ctrlS/totori/book/service/StableDiffusionService.java
+++ b/src/main/java/ctrlS/totori/book/service/StableDiffusionService.java
@@ -1,5 +1,7 @@
 package ctrlS.totori.book.service;
 
+import ctrlS.totori.global.exception.CustomException;
+import ctrlS.totori.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -44,7 +46,7 @@ public class StableDiffusionService {
             String base64Image = (String) response.getBody().get("image");
             return Base64.getDecoder().decode(base64Image);
         } catch (Exception e) {
-            throw new RuntimeException("이미지 생성 실패: " + e.getMessage(), e);
+            throw new CustomException(ErrorCode.IMAGE_CREATE_ERROR);
         }
     }
 }

--- a/src/main/java/ctrlS/totori/book/service/StableDiffusionService.java
+++ b/src/main/java/ctrlS/totori/book/service/StableDiffusionService.java
@@ -46,6 +46,7 @@ public class StableDiffusionService {
             String base64Image = (String) response.getBody().get("image");
             return Base64.getDecoder().decode(base64Image);
         } catch (Exception e) {
+            System.err.println("🚨 기타 에러: " + e.getMessage());
             throw new CustomException(ErrorCode.IMAGE_CREATE_ERROR);
         }
     }

--- a/src/main/java/ctrlS/totori/book/service/StableDiffusionService.java
+++ b/src/main/java/ctrlS/totori/book/service/StableDiffusionService.java
@@ -1,0 +1,50 @@
+package ctrlS.totori.book.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Base64;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class StableDiffusionService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${stability.api-key}")
+    private String apiKey;
+
+    public byte[] generateImage(String prompt, long seed) {
+        String url = "https://api.stability.ai/v2beta/stable-image/generate/sd3";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        headers.setBearerAuth(apiKey);
+        headers.set("Accept", "application/json");
+
+        String enhancedPrompt = "cute children's book illustration, watercolor style, " + prompt;
+
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("prompt", enhancedPrompt);
+        body.add("model", "sd3.5-flash");
+        body.add("aspect-ratio", "1:1");
+        body.add("output_format", "png");
+        body.add("seed", seed); //하나의 동화책에 같은 시드를 부여하여 이미지간 연결성을 높입니다.
+
+        HttpEntity<MultiValueMap<String, Object>> entity = new HttpEntity<>(body, headers);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.postForEntity(url, entity, Map.class);
+            String base64Image = (String) response.getBody().get("image");
+            return Base64.getDecoder().decode(base64Image);
+        } catch (Exception e) {
+            throw new RuntimeException("이미지 생성 실패: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/ctrlS/totori/global/config/AsyncConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package ctrlS.totori.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "imageExecutor")
+    public Executor imageExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(3);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("Image-Async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/ctrlS/totori/global/config/RestTemplateConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package ctrlS.totori.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
     INVALID_OR_EXPIRED_CONNECT_CODE(400, "유효하지 않거나 만료된 연결 코드입니다."),
     ALREADY_CONNECTED_CHILD(409, "이미 연결된 아동 계정입니다.");
 
+    // image
+    IMAGE_CREATE_ERROR(500, "이미지 생성에 실패했습니다");
+
     private final int status;
     private final String message;
 }

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
     EXPIRED_TOKEN(401, "만료된 토큰입니다."),
 
     // Badge
-    BADGE_NOT_FOUND(404, "보유한 뱃지가 없습니다.");
+    BADGE_NOT_FOUND(404, "보유한 뱃지가 없습니다."),
 
     // connect
     ONLY_CHILD_CAN_CREATE_CONNECT_CODE(403, "아동 계정만 연결 코드를 생성할 수 있습니다."),

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -31,7 +31,7 @@ public enum ErrorCode {
     ONLY_CHILD_CAN_CREATE_CONNECT_CODE(403, "아동 계정만 연결 코드를 생성할 수 있습니다."),
     ONLY_PARENT_CAN_CONNECT_CHILD(403, "부모 계정만 연결 코드를 입력할 수 있습니다."),
     INVALID_OR_EXPIRED_CONNECT_CODE(400, "유효하지 않거나 만료된 연결 코드입니다."),
-    ALREADY_CONNECTED_CHILD(409, "이미 연결된 아동 계정입니다.");
+    ALREADY_CONNECTED_CHILD(409, "이미 연결된 아동 계정입니다."),
 
     // image
     IMAGE_CREATE_ERROR(500, "이미지 생성에 실패했습니다");


### PR DESCRIPTION
## 🐣 작업 개요
> stable diffusion을 활용한 이미지 생성을 동화책 생성과 연결합니다. 

## 📍 변경 사항
RestTemplateConfig, ImageStorageService, LocalImageStorageService, BookPage, StableDiffusionService, BookService, .gitignore
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
현재 member 엔티티에 레벨이 없는 상태이기 때문에 테스트시 sql 문으로 직접 레벨을 입력 후에 실행해야 정상적으로 돌아갑니다. 

하나의 동화책 안에서 비슷한 느낌의 이미지 생성을 위해 seed를 추가하였습니다. 하나의 동화책 내에서는 동일 seed로 제작되어 이미지간 연관성이 높아집니다(근데 똑같이 나오게 하려면 더 좋은 모델을 써야할 것 같아요....)
<img width="1710" height="1107" alt="스크린샷 2026-03-26 오전 12 36 18" src="https://github.com/user-attachments/assets/3c25d461-c96b-41f3-999a-257faf51c211" />
<img width="512" height="512" alt="9f16b0dd-9234-4fec-9985-66bc396c1707_page_3" src="https://github.com/user-attachments/assets/c7856b26-0de6-4eb7-a26c-3360257d2c52" />
<img width="512" height="512" alt="b66dac1d-ccf1-4572-af8c-3d9708122eca_page_6" src="https://github.com/user-attachments/assets/d087e19e-32f6-4926-ad79-8a7898688001" />


## 🔍 참고 사항
application.yml 수정해주세요.
현재 s3 연결을 하지 않아서 로컬에 이미지를 저장하는 형식으로 구현되어있습니다. C: 파일로 경로를 설정했는데 맥북에는 해당 파일이 없어서 그냥 프로젝트 파일 안에 생성되더라고요! 확인부탁드립니다. 

## ✨ 관련 이슈
- (ex) closes #40

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [ ] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
