### PR TITLE
[Refactor] 동화 생성 시 표지 이미지 프롬프트 추가

### DIFF
--- a/src/main/java/ctrlS/totori/book/dto/BookGenerateResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/BookGenerateResponse.java
@@ -8,6 +8,7 @@ public record BookGenerateResponse(
         Long bookId,
         String title,
         int totalPages,
+        String coverImagePrompt,
         List<BookPageResponse> pages
 ) {
     public static BookGenerateResponse from(Book book) {
@@ -15,6 +16,7 @@ public record BookGenerateResponse(
                 book.getId(),
                 book.getTitle(),
                 book.getTotalPages(),
+                book.getCoverImagePrompt(),
                 book.getPages().stream()
                         .map(BookPageResponse::from)
                         .toList()

--- a/src/main/java/ctrlS/totori/book/dto/FastApiStoryResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/FastApiStoryResponse.java
@@ -6,6 +6,10 @@ import java.util.List;
 
 public record FastApiStoryResponse(
         String title,
+
+        @JsonProperty("cover_image_prompt")
+        String coverImagePrompt,
+
         List<FastApiPageResponse> pages
 ) {
 }

--- a/src/main/java/ctrlS/totori/book/entity/Book.java
+++ b/src/main/java/ctrlS/totori/book/entity/Book.java
@@ -36,6 +36,8 @@ public class Book extends BaseTimeEntity {
 
     private String coverImageUrl;
 
+    private String coverImagePrompt;
+
     @Column(nullable = false)
     private int totalPages;
 
@@ -45,10 +47,11 @@ public class Book extends BaseTimeEntity {
     private List<BookPage> pages = new ArrayList<>();
 
     @Builder
-    public Book(Member member, String title, String coverImageUrl, int totalPages) {
+    public Book(Member member, String title, String coverImageUrl, String coverImagePrompt, int totalPages) {
         this.member = member;
         this.title = title;
         this.coverImageUrl = coverImageUrl;
+        this.coverImagePrompt = coverImagePrompt;
         this.totalPages = totalPages;
     }
 
@@ -57,6 +60,7 @@ public class Book extends BaseTimeEntity {
                 .member(member)
                 .title(response.title())
                 .coverImageUrl(null)
+                .coverImagePrompt(response.coverImagePrompt())
                 .totalPages(response.pages().size())
                 .build();
     }


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 동화 생성 시 표지 이미지 프롬프트 추가했습니다.

## 📍 변경 사항
Update: BookGenerateResponse, FastApiStoryResponse, Book
  
## 🚧 구현 중 겪은 이슈 및 해결 방법


## 🔍 참고 사항
FastAPI에서 표지 이미지 프롬프트 추가, 등장인물 외형 고정값 삽입, 총 장면 수와 한 장면에 들어가는 문장 수 응답으로 받는 로직 추가해두었습니다.
현재 postman에서 동화 생성 API 실행 시 수정 사항이 반영된 결과를 확인할 수 있습니다.
<img width="651" height="833" alt="스크린샷 2026-03-27 오전 3 24 15" src="https://github.com/user-attachments/assets/befec22a-586e-4854-9f2a-f1b343d9ab36" />


## ✨ 관련 이슈
- closes #44 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [ ] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
