### PR TITLE
[Fix] OAuth2 인증 에러 리다이렉트 오류 해결

### DIFF
--- a/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package ctrlS.totori.global.config;
 
 import ctrlS.totori.auth.service.CustomOAuth2UserService;
+import ctrlS.totori.global.exception.ErrorCode;
 import ctrlS.totori.global.security.JwtAuthenticationFilter;
 import ctrlS.totori.global.security.oauth.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +34,33 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(ErrorCode.UNAUTHORIZED_ACCESS.getStatus());
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write(
+                                    String.format(
+                                            "{\"status\":%d,\"message\":\"%s\"}",
+                                            ErrorCode.UNAUTHORIZED_ACCESS.getStatus(),
+                                            ErrorCode.UNAUTHORIZED_ACCESS.getMessage()
+                                    )
+                            );
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.setStatus(ErrorCode.ACCESS_DENIED.getStatus());
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write(
+                                    String.format(
+                                            "{\"status\":%d,\"message\":\"%s\"}",
+                                            ErrorCode.ACCESS_DENIED.getStatus(),
+                                            ErrorCode.ACCESS_DENIED.getMessage()
+                                    )
+                            );
+                        })
+                )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/login/success").permitAll()

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     // Default
     ERROR(400, "요청 처리에 실패했습니다."),
     UNAUTHORIZED_ACCESS(401, "인증되지 않은 사용자입니다."),
+    ACCESS_DENIED(403, "접근 권한이 없습니다."),
 
     // Member
     STAT_NOT_FOUND(404, "사용자의 통계 정보를 찾을 수 없습니다."),

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
     EXPIRED_TOKEN(401, "만료된 토큰입니다."),
 
     // Badge
-    BADGE_NOT_FOUND(404, "보유한 뱃지가 없습니다.");
+    BADGE_NOT_FOUND(404, "보유한 뱃지가 없습니다."),
 
     // connect
     ONLY_CHILD_CAN_CREATE_CONNECT_CODE(403, "아동 계정만 연결 코드를 생성할 수 있습니다."),

--- a/src/main/java/ctrlS/totori/global/security/CustomAuthenticationException.java
+++ b/src/main/java/ctrlS/totori/global/security/CustomAuthenticationException.java
@@ -7,8 +7,9 @@ import org.springframework.security.core.AuthenticationException;
 @Getter
 public class CustomAuthenticationException extends AuthenticationException {
     private final ErrorCode errorCode;
+
     public CustomAuthenticationException(ErrorCode errorCode) {
         super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
-
 }

--- a/src/main/java/ctrlS/totori/global/security/CustomAuthenticationException.java
+++ b/src/main/java/ctrlS/totori/global/security/CustomAuthenticationException.java
@@ -1,8 +1,11 @@
 package ctrlS.totori.global.security;
 
 import ctrlS.totori.global.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
 
-public class CustomAuthenticationException extends RuntimeException {
+@Getter
+public class CustomAuthenticationException extends AuthenticationException {
     private final ErrorCode errorCode;
 
     public CustomAuthenticationException(ErrorCode errorCode) {
@@ -10,7 +13,4 @@ public class CustomAuthenticationException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
 }

--- a/src/main/java/ctrlS/totori/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/ctrlS/totori/global/security/JwtAuthenticationFilter.java
@@ -37,18 +37,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 throw new CustomAuthenticationException(ErrorCode.LOGGED_OUT_TOKEN);
             }
 
-            if (jwtTokenProvider.validateToken(token)) {
-                Long memberId = Long.valueOf(jwtTokenProvider.getUserPk(token));
-                String role = jwtTokenProvider.getRole(token);
-
-                CustomUserPrincipal principal = new CustomUserPrincipal(memberId, role);
-
-                var authorities = List.of(new SimpleGrantedAuthority(role));
-                var authentication = new UsernamePasswordAuthenticationToken(principal, null, authorities);
-
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+            if (!jwtTokenProvider.validateToken(token)) {
+                throw new CustomAuthenticationException(ErrorCode.UNAUTHORIZED_ACCESS);
             }
+
+            Long memberId = Long.valueOf(jwtTokenProvider.getUserPk(token));
+            String role = jwtTokenProvider.getRole(token);
+
+            CustomUserPrincipal principal = new CustomUserPrincipal(memberId, role);
+
+            var authorities = List.of(new SimpleGrantedAuthority(role));
+            var authentication = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/ctrlS/totori/report/repository/SpeakingErrorTypeRepository.java
+++ b/src/main/java/ctrlS/totori/report/repository/SpeakingErrorTypeRepository.java
@@ -13,6 +13,6 @@ public interface SpeakingErrorTypeRepository extends JpaRepository<SpeakingError
     List<SpeakingErrorType> findTop4ByMemberOrderByCountDesc(Member member);
 
     // 전체 에러 개수 합계
-    @Query("SELECT SUM(e.count) FROM ErrorType e WHERE e.member = :member")
+    @Query("SELECT SUM(e.count) FROM SpeakingErrorType e WHERE e.member = :member")
     int sumCountByMember(@Param("member") Member member);
 }


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 인증 에러 발생 시 카카오 로그인 창으로 리다이렉트되는 문제 해결했습니다.

## 📍 변경 사항
Update: JwtAuthenticationFilter, CustomAuthenticationException, SpeakingErrorTypeRepository

## ✨ 관련 이슈
- closes #46 

## 🔍 참고 사항
SpeakingErrorTypeRepository에서 쿼리 테이블명이 ErrorType로 되어 있어서 SpeakingErrorType으로 수정했습니다.
<img width="670" height="104" alt="스크린샷 2026-04-03 오후 10 46 35" src="https://github.com/user-attachments/assets/59be844a-86e4-4606-bce3-2db8c3933ef1" />

## 🔧 변경 유형
* [x] Bug Fix (fix)
* [ ] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [x] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
