### PR TITLE
[Feat] api 성공 응답 형식 변경

### DIFF
--- a/src/main/java/ctrlS/totori/auth/controller/AuthController.java
+++ b/src/main/java/ctrlS/totori/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import ctrlS.totori.auth.dto.LoginRequest;
 import ctrlS.totori.auth.dto.SignUpRequest;
 import ctrlS.totori.auth.dto.TokenResponse;
 import ctrlS.totori.auth.service.AuthService;
+import ctrlS.totori.global.response.dto.BaseResponse;
 import ctrlS.totori.member.entity.Role;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,7 +16,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -33,9 +33,9 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청값", content = @Content),
             @ApiResponse(responseCode = "409", description = "이미 존재하는 아이디", content = @Content)})
     @PostMapping("/signup")
-    public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest request) {
+    public BaseResponse<Void> signUp(@Valid @RequestBody SignUpRequest request) {
         authService.signUp(request);
-        return ResponseEntity.ok().build();
+        return BaseResponse.created();
     }
 
     @Operation(summary = "자체 로그인", description = "아이디와 비밀번호로 로그인하고 JWT 토큰을 발급받습니다.")
@@ -46,9 +46,9 @@ public class AuthController {
             @ApiResponse(responseCode = "404", description = "가입되지 않은 아이디", content = @Content)
     })
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+    public BaseResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
         TokenResponse tokenResponse = authService.login(request);
-        return ResponseEntity.ok(tokenResponse);
+        return BaseResponse.ok(tokenResponse);
     }
 
     @Operation(summary = "카카오 로그인", description = "역할을 전달받아 세션에 저장한 뒤 카카오 OAuth2 로그인 페이지로 리다이렉트합니다.")
@@ -76,8 +76,8 @@ public class AuthController {
             @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰 혹은 이미 로그아웃된 토큰", content = @Content)
     })
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@RequestHeader(value = "Authorization", required = false) String bearerToken) {
+    public BaseResponse<Void> logout(@RequestHeader(value = "Authorization", required = false) String bearerToken) {
         authService.logout(bearerToken);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok();
     }
 }

--- a/src/main/java/ctrlS/totori/auth/dto/SignUpRequest.java
+++ b/src/main/java/ctrlS/totori/auth/dto/SignUpRequest.java
@@ -1,6 +1,7 @@
 package ctrlS.totori.auth.dto;
 
 import ctrlS.totori.member.entity.Role;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class SignUpRequest {
     @NotBlank(message = "아이디는 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String loginId;
 
     @NotBlank(message = "비밀번호는 필수입니다.")

--- a/src/main/java/ctrlS/totori/badge/controller/BadgeController.java
+++ b/src/main/java/ctrlS/totori/badge/controller/BadgeController.java
@@ -1,12 +1,13 @@
 package ctrlS.totori.badge.controller;
+
 import ctrlS.totori.badge.dto.BadgeResponseDto;
 import ctrlS.totori.badge.dto.CategoryBadgeResponseDto;
 import ctrlS.totori.badge.dto.MemberBadgeResponseDto;
 import ctrlS.totori.badge.entity.BadgeCategory;
 import ctrlS.totori.badge.service.BadgeService;
+import ctrlS.totori.global.response.dto.BaseResponse;
 import ctrlS.totori.global.security.CustomUserPrincipal;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,27 +22,27 @@ public class BadgeController {
 
     // 전체 뱃지 조회
     @GetMapping
-    public ResponseEntity<List<BadgeResponseDto>> getAllBadges() {
-        return ResponseEntity.ok(badgeService.getAllBadges());
+    public BaseResponse<List<BadgeResponseDto>> getAllBadges() {
+        return BaseResponse.ok(badgeService.getAllBadges());
     }
 
     // 유저의 뱃지 조회
     @GetMapping("/my")
-    public ResponseEntity<List<MemberBadgeResponseDto>> getMemberBadges(@AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ResponseEntity.ok(badgeService.getMemberBadges(principal.getMemberId()));
+    public BaseResponse<List<MemberBadgeResponseDto>> getMemberBadges(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        return BaseResponse.ok(badgeService.getMemberBadges(principal.getMemberId()));
     }
 
     // 대표 뱃지 조회
     @GetMapping("/my/representative")
-    public ResponseEntity<MemberBadgeResponseDto> getRepresentativeBadge(@AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ResponseEntity.ok(badgeService.getRepresentativeBadge(principal.getMemberId()));
+    public BaseResponse<MemberBadgeResponseDto> getRepresentativeBadge(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        return BaseResponse.ok(badgeService.getRepresentativeBadge(principal.getMemberId()));
     }
 
     // 특정 카테고리의 상세 뱃지 정보 조회
     @GetMapping("/my/categories/{category}")
-    public ResponseEntity<CategoryBadgeResponseDto> getCategoryBadgeDetails(
+    public BaseResponse<CategoryBadgeResponseDto> getCategoryBadgeDetails(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable BadgeCategory category) {
-        return ResponseEntity.ok(badgeService.getCategoryBadgeDetail(principal.getMemberId(), category));
+        return BaseResponse.ok(badgeService.getCategoryBadgeDetail(principal.getMemberId(), category));
     }
 }

--- a/src/main/java/ctrlS/totori/book/controller/BookController.java
+++ b/src/main/java/ctrlS/totori/book/controller/BookController.java
@@ -3,6 +3,7 @@ package ctrlS.totori.book.controller;
 import ctrlS.totori.book.dto.BookGenerateRequest;
 import ctrlS.totori.book.dto.BookGenerateResponse;
 import ctrlS.totori.book.service.BookService;
+import ctrlS.totori.global.response.dto.BaseResponse;
 import ctrlS.totori.global.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -12,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,10 +34,10 @@ public class BookController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
     })
     @PostMapping("/generate")
-    public ResponseEntity<BookGenerateResponse> generateBook(
+    public BaseResponse<BookGenerateResponse> generateBook(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody BookGenerateRequest request
             ) {
-        return ResponseEntity.ok(bookService.generateBook(principal.getMemberId(), request));
+        return BaseResponse.ok(bookService.generateBook(principal.getMemberId(), request));
     }
 }

--- a/src/main/java/ctrlS/totori/global/response/ApiResponseAdvice.java
+++ b/src/main/java/ctrlS/totori/global/response/ApiResponseAdvice.java
@@ -1,0 +1,31 @@
+package ctrlS.totori.global.response;
+
+import ctrlS.totori.global.response.dto.BaseResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ApiResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return returnType.getParameterType().equals(BaseResponse.class);
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request, ServerHttpResponse response) {
+
+        if (body instanceof BaseResponse<?> baseResponse) {
+            response.setStatusCode(HttpStatusCode.valueOf(baseResponse.getStatus()));
+        }
+        return body;
+    }
+}

--- a/src/main/java/ctrlS/totori/global/response/SuccessCode.java
+++ b/src/main/java/ctrlS/totori/global/response/SuccessCode.java
@@ -1,0 +1,17 @@
+package ctrlS.totori.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode {
+
+    SUCCESS(HttpStatus.OK,"SUCCESS", "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "CREATED", "새 리소스가 생성되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/ctrlS/totori/global/response/SuccessCode.java
+++ b/src/main/java/ctrlS/totori/global/response/SuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
     SUCCESS(HttpStatus.OK,"SUCCESS", "요청이 성공적으로 처리되었습니다."),
-    CREATED(HttpStatus.CREATED, "CREATED", "새 리소스가 생성되었습니다.");
+    CREATED(HttpStatus.CREATED, "CREATED", "새 리소스가 생성되었습니다."),
+    NO_CONTENT(HttpStatus.NO_CONTENT, "NO_CONTENT", "요청이 성공적으로 처리되었으나, 반환할 데이터가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/ctrlS/totori/global/response/dto/BaseResponse.java
+++ b/src/main/java/ctrlS/totori/global/response/dto/BaseResponse.java
@@ -22,6 +22,15 @@ public class BaseResponse<T> {
         );
     }
 
+    public static <T> BaseResponse<T> ok() {
+        return new BaseResponse<>(
+                SuccessCode.SUCCESS.getHttpStatus().value(),
+                SuccessCode.SUCCESS.getCode(),
+                SuccessCode.SUCCESS.getMessage(),
+                null
+        );
+    }
+
     // 201 Created
     public static <T> BaseResponse<T> created() {
         return new BaseResponse<>(

--- a/src/main/java/ctrlS/totori/global/response/dto/BaseResponse.java
+++ b/src/main/java/ctrlS/totori/global/response/dto/BaseResponse.java
@@ -40,4 +40,14 @@ public class BaseResponse<T> {
                 null
         );
     }
+
+    // 204 No Content
+    public static <T> BaseResponse<T> noContent() {
+        return new BaseResponse<>(
+                SuccessCode.NO_CONTENT.getHttpStatus().value(),
+                SuccessCode.NO_CONTENT.getCode(),
+                SuccessCode.NO_CONTENT.getMessage(),
+                null
+        );
+    }
 }

--- a/src/main/java/ctrlS/totori/global/response/dto/BaseResponse.java
+++ b/src/main/java/ctrlS/totori/global/response/dto/BaseResponse.java
@@ -1,0 +1,34 @@
+package ctrlS.totori.global.response.dto;
+
+import ctrlS.totori.global.response.SuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BaseResponse<T> {
+    private int status;
+    private String code;
+    private String message;
+    private T data;
+
+    // 200 OK
+    public static <T> BaseResponse<T> ok(T data) {
+        return new BaseResponse<>(
+                SuccessCode.SUCCESS.getHttpStatus().value(),
+                SuccessCode.SUCCESS.getCode(),
+                SuccessCode.SUCCESS.getMessage(),
+                data
+        );
+    }
+
+    // 201 Created
+    public static <T> BaseResponse<T> created() {
+        return new BaseResponse<>(
+                SuccessCode.CREATED.getHttpStatus().value(),
+                SuccessCode.CREATED.getCode(),
+                SuccessCode.CREATED.getMessage(),
+                null
+        );
+    }
+}

--- a/src/main/java/ctrlS/totori/member/controller/ConnectController.java
+++ b/src/main/java/ctrlS/totori/member/controller/ConnectController.java
@@ -1,5 +1,6 @@
 package ctrlS.totori.member.controller;
 
+import ctrlS.totori.global.response.dto.BaseResponse;
 import ctrlS.totori.global.security.CustomUserPrincipal;
 import ctrlS.totori.member.dto.ConnectCodeResponse;
 import ctrlS.totori.member.dto.ConnectRequest;
@@ -12,8 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,10 +32,10 @@ public class ConnectController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청값", content = @Content)
     })
     @PostMapping("/code")
-    public ResponseEntity<ConnectCodeResponse> createCode(@AuthenticationPrincipal CustomUserPrincipal principal) {
+    public BaseResponse<ConnectCodeResponse> createCode(@AuthenticationPrincipal CustomUserPrincipal principal) {
         String code = connectService.createConnectCode(principal.getMemberId());
 
-        return ResponseEntity.ok(new ConnectCodeResponse(code, 600));
+        return BaseResponse.ok(new ConnectCodeResponse(code, 600));
     }
 
     @Operation(summary = "아동-보호자 계정 연결")
@@ -45,10 +44,10 @@ public class ConnectController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청값 또는 유효하지 않은 연결 코드", content = @Content)
     })
     @PostMapping
-    public ResponseEntity<Void> linkChild(
+    public BaseResponse<Void> linkChild(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody ConnectRequest request) {
         connectService.connectToChild(principal.getMemberId(), request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return BaseResponse.ok();
     }
 }

--- a/src/main/java/ctrlS/totori/member/controller/MemberController.java
+++ b/src/main/java/ctrlS/totori/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package ctrlS.totori.member.controller;
 
+import ctrlS.totori.global.response.dto.BaseResponse;
 import ctrlS.totori.global.security.CustomUserPrincipal;
 import ctrlS.totori.member.dto.AcornResponse;
 import ctrlS.totori.member.dto.MemberMeResponse;
@@ -14,7 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,8 +34,8 @@ public class MemberController {
             @ApiResponse(responseCode = "404", description = "존재하는 사용자가 없습니다.", content = @Content)
     })
     @GetMapping("/me")
-    public ResponseEntity<MemberMeResponse> getMyInfo(@AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ResponseEntity.ok(memberService.getMyInfo(principal.getMemberId()));
+    public BaseResponse<MemberMeResponse> getMyInfo(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        return BaseResponse.ok(memberService.getMyInfo(principal.getMemberId()));
     }
 
     // 회원 도토리 개수 조회
@@ -45,10 +45,10 @@ public class MemberController {
             @ApiResponse(responseCode = "404", description = "존재하는 사용자가 없습니다.", content = @Content)
     })
     @GetMapping("/me/acorns")
-    public ResponseEntity<AcornResponse> getMyAcorn(
+    public BaseResponse<AcornResponse> getMyAcorn(
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        return ResponseEntity.ok(memberService.getMyAcorn(principal.getMemberId()));
+        return BaseResponse.ok(memberService.getMyAcorn(principal.getMemberId()));
     }
 
     // 회원 정보 수정
@@ -59,11 +59,11 @@ public class MemberController {
             @ApiResponse(responseCode = "404", description = "존재하는 사용자가 없습니다.", content = @Content)
     })
     @PatchMapping("/me")
-    public ResponseEntity<UpdateMemberResponse> updateMyInfo(
+    public BaseResponse<UpdateMemberResponse> updateMyInfo(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestBody @Valid UpdateMemberRequest request
             ) {
-        return ResponseEntity.ok(memberService.updateMyInfo(principal.getMemberId(), request));
+        return BaseResponse.ok(memberService.updateMyInfo(principal.getMemberId(), request));
     }
 
     // 회원 탈퇴
@@ -73,11 +73,11 @@ public class MemberController {
             @ApiResponse(responseCode = "404", description = "존재하는 사용자가 없습니다.", content = @Content)
     })
     @DeleteMapping("/me")
-    public ResponseEntity<Void> deleteMyAccount(
+    public BaseResponse<Void> deleteMyAccount(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestHeader("Authorization") String bearerToken
     ) {
         memberService.deleteMyAccount(principal.getMemberId(), bearerToken);
-        return ResponseEntity.noContent().build();
+        return BaseResponse.noContent();
     }
 }

--- a/src/main/java/ctrlS/totori/report/controller/ReportController.java
+++ b/src/main/java/ctrlS/totori/report/controller/ReportController.java
@@ -1,5 +1,6 @@
 package ctrlS.totori.report.controller;
 
+import ctrlS.totori.global.response.dto.BaseResponse;
 import ctrlS.totori.global.security.CustomUserPrincipal;
 import ctrlS.totori.report.dto.response.TotalReportResponse;
 import ctrlS.totori.report.dto.response.WeeklyReportResponse;
@@ -10,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,9 +28,9 @@ public class ReportController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content)
     })
     @GetMapping("/week")
-    public ResponseEntity<WeeklyReportResponse> getWeeklyReport(@AuthenticationPrincipal CustomUserPrincipal principal){
+    public BaseResponse<WeeklyReportResponse> getWeeklyReport(@AuthenticationPrincipal CustomUserPrincipal principal){
         WeeklyReportResponse response = reportService.getWeeklyReport(principal.getMemberId());
-        return ResponseEntity.ok(response);
+        return BaseResponse.ok(response);
     }
 
     @Operation(summary = "전체 레포트 조회", description = "전체 레포트를 조회합니다.")
@@ -38,8 +38,8 @@ public class ReportController {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content)
     })
     @GetMapping("/total")
-    public ResponseEntity<TotalReportResponse> getTotalReport(@AuthenticationPrincipal CustomUserPrincipal principal){
+    public BaseResponse<TotalReportResponse> getTotalReport(@AuthenticationPrincipal CustomUserPrincipal principal){
         TotalReportResponse response = reportService.getTotalReport(principal.getMemberId());
-        return ResponseEntity.ok(response);
+        return BaseResponse.ok(response);
     }
 }

--- a/src/main/java/ctrlS/totori/report/repository/SpeakingErrorTypeRepository.java
+++ b/src/main/java/ctrlS/totori/report/repository/SpeakingErrorTypeRepository.java
@@ -13,6 +13,6 @@ public interface SpeakingErrorTypeRepository extends JpaRepository<SpeakingError
     List<SpeakingErrorType> findTop4ByMemberOrderByCountDesc(Member member);
 
     // 전체 에러 개수 합계
-    @Query("SELECT SUM(e.count) FROM ErrorType e WHERE e.member = :member")
+    @Query("SELECT SUM(e.count) FROM SpeakingErrorType e WHERE e.member = :member")
     int sumCountByMember(@Param("member") Member member);
 }


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- api 성공 응답 형식을 변경하였습니다.

## 📍 변경 사항
- 전체 controller
- BaseResponse, ApiResponseAdvice, SuccessCode 추가
- SignUpRequest dto 수정
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
- 204 no content만 자꾸 응답 json이 안떠서 코드를 계속 뜯어보고있었는데..
204는 응답 본문(Body)을 가질 수 없다고 엄격하게 정의를 해놓아서 안뜨는거였대요..^^ 알아서 바디를 안보냄


## 🔍 참고 사항
### 프론트 204 응답 방법 논의필요
- 위에 겪은 이슈에서 적은 것 처럼 204는 응답형식 통일이 안되는데, 지금 회원탈퇴할때만 204를 써서, 이걸 200으로 바꿀지, 아니면 그냥  body 없이 들어와도 괜찮을지만 알려주세요!
<img width="493" height="87" alt="image" src="https://github.com/user-attachments/assets/edb895e6-b086-4dcd-a38d-941e7785a37a" />

### 로그인 dto 수정됨
- 로그인할 때 이메일 형식으로 넣지 않으면 기존에는 entity에서만 제약이 걸려있어서 그냥 서버에러가 나오길래, SignUpRequest dto에 `@Email(message = "이메일 형식이 올바르지 않습니다.")` 어노테이션만 하나 추가했습니다!
<img width="325" height="131" alt="image" src="https://github.com/user-attachments/assets/eb4631fb-8a9b-453b-91de-50582f3cd341" />

### 응답 결과
- 200 ok
<img width="237" height="120" alt="image" src="https://github.com/user-attachments/assets/d9d19124-732b-4794-884e-f7c00c313e87" />

- 201 created
<img width="490" height="111" alt="image" src="https://github.com/user-attachments/assets/a8555202-e6a5-4a44-bc11-cd1b6f55ff82" />

- 204 no content
<img width="493" height="87" alt="image" src="https://github.com/user-attachments/assets/edb895e6-b086-4dcd-a38d-941e7785a37a" />

- 에러메세지는 기존과 동일
<img width="325" height="131" alt="image" src="https://github.com/user-attachments/assets/eb4631fb-8a9b-453b-91de-50582f3cd341" />


## ✨ 관련 이슈
- closes #47

## 🔧 변경 유형
* [x] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
