### PR TITLE
[Feat] JWT refresh token 기반 토큰 재발급 로직 구현

### DIFF
--- a/src/main/java/ctrlS/totori/auth/controller/AuthController.java
+++ b/src/main/java/ctrlS/totori/auth/controller/AuthController.java
@@ -88,9 +88,9 @@ public class AuthController {
             @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token", content = @Content)
     })
     @PostMapping("/reissue")
-    public ResponseEntity<TokenResponse> reissue(
+    public BaseResponse<TokenResponse> reissue(
             @RequestHeader(value = "Authorization", required = false) String bearerToken) {
         TokenResponse tokenResponse = authService.reissue(bearerToken);
-        return ResponseEntity.ok(tokenResponse);
+        return BaseResponse.ok(tokenResponse);
     }
 }

--- a/src/main/java/ctrlS/totori/auth/controller/AuthController.java
+++ b/src/main/java/ctrlS/totori/auth/controller/AuthController.java
@@ -80,4 +80,17 @@ public class AuthController {
         authService.logout(bearerToken);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "Access Token 재발급", description = "Refresh Token을 Authorization 헤더에 담아 요청하면 새 Access Token과 Refresh Token을 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재발급 성공",
+                    content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token", content = @Content)
+    })
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponse> reissue(
+            @RequestHeader(value = "Authorization", required = false) String bearerToken) {
+        TokenResponse tokenResponse = authService.reissue(bearerToken);
+        return ResponseEntity.ok(tokenResponse);
+    }
 }

--- a/src/main/java/ctrlS/totori/auth/dto/OAuth2Attribute.java
+++ b/src/main/java/ctrlS/totori/auth/dto/OAuth2Attribute.java
@@ -7,19 +7,18 @@ import java.util.Map;
 
 public record OAuth2Attribute(
         Map<String, Object> attributes,
-        String nameAttributeKey,
         String name,
         String email,
         String providerId
         ) {
-    public static OAuth2Attribute of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+    public static OAuth2Attribute of(String registrationId, Map<String, Object> attributes) {
             if ("kakao".equals(registrationId)) {
-                    return ofKakao(userNameAttributeName, attributes);
+                    return ofKakao(attributes);
             }
             throw new CustomException(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
     }
 
-    private static OAuth2Attribute ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+    private static OAuth2Attribute ofKakao(Map<String, Object> attributes) {
             Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
             Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
             String nickname = (String) kakaoProfile.get("nickname");
@@ -28,7 +27,6 @@ public record OAuth2Attribute(
 
             return new OAuth2Attribute(
                     attributes,
-                    userNameAttributeName,
                     nickname,
                     email,
                     providerId

--- a/src/main/java/ctrlS/totori/auth/dto/TokenResponse.java
+++ b/src/main/java/ctrlS/totori/auth/dto/TokenResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class TokenResponse {
-    private String token;
+    private String accessToken;
+    private String refreshToken;
     private String role;
 }

--- a/src/main/java/ctrlS/totori/auth/service/AuthRedisService.java
+++ b/src/main/java/ctrlS/totori/auth/service/AuthRedisService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthRedisService {
     private static final String LOGOUT_VALUE = "logout";
+    private static final String REFRESH_TOKEN_PREFIX = "RT:";
+    private static final long REFRESH_TOKEN_EXPIRE_SECONDS = 14 * 24 * 60 * 60; // 14일
 
     private final RedisUtil redisUtil;
 
@@ -17,5 +19,24 @@ public class AuthRedisService {
 
     public boolean isBlacklisted(String token) {
         return redisUtil.hasKey(token);
+    }
+
+    // 로그인 시 refresh token 저장
+    public void saveRefreshToken(Long memberId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + memberId;
+        redisUtil.setDataExpire(key, refreshToken, REFRESH_TOKEN_EXPIRE_SECONDS);
+    }
+
+    public String getRefreshToken(Long memberId) {
+        return redisUtil.getData(REFRESH_TOKEN_PREFIX + memberId);
+    }
+
+    public void deleteRefreshToken(Long memberId) {
+        redisUtil.deleteDate(REFRESH_TOKEN_PREFIX + memberId);
+    }
+
+    public boolean isValidRefreshToken(Long memberId, String refreshToken) {
+        String storedToken = getRefreshToken(memberId);
+        return storedToken != null && storedToken.equals(refreshToken);
     }
 }

--- a/src/main/java/ctrlS/totori/auth/service/AuthRedisService.java
+++ b/src/main/java/ctrlS/totori/auth/service/AuthRedisService.java
@@ -32,7 +32,7 @@ public class AuthRedisService {
     }
 
     public void deleteRefreshToken(Long memberId) {
-        redisUtil.deleteDate(REFRESH_TOKEN_PREFIX + memberId);
+        redisUtil.deleteData(REFRESH_TOKEN_PREFIX + memberId);
     }
 
     public boolean isValidRefreshToken(Long memberId, String refreshToken) {

--- a/src/main/java/ctrlS/totori/auth/service/AuthService.java
+++ b/src/main/java/ctrlS/totori/auth/service/AuthService.java
@@ -58,11 +58,17 @@ public class AuthService {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
 
+        String memberId = String.valueOf(member.getId());
+        String role = String.valueOf(member.getRole());
+
         // 비밀번호까지 맞으면 JWT 토큰 생성
-        String token = jwtTokenProvider.createToken(String.valueOf(member.getId()), member.getRole().name());
+        String accessToken = jwtTokenProvider.createAccessToken(memberId, role);
+        String refreshToken = jwtTokenProvider.createRefreshToken(memberId);
+
+        authRedisService.saveRefreshToken(member.getId(), refreshToken);
 
         // 토큰과 권한 정보 반환
-        return new TokenResponse(token, member.getRole().name());
+        return new TokenResponse(accessToken, refreshToken, role);
     }
 
     public void logout(String bearerToken) {
@@ -71,6 +77,36 @@ public class AuthService {
         if (token != null && jwtTokenProvider.validateToken(token)) {
             long expiration = jwtTokenProvider.getRemainingSeconds(token);
             authRedisService.blacklistToken(token, expiration);
+
+            Long memberId = Long.valueOf(jwtTokenProvider.getUserPk(token));
+            authRedisService.deleteRefreshToken(memberId);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public TokenResponse reissue(String bearerToken) {
+        String refreshToken = jwtTokenProvider.resolveToken(bearerToken);
+
+        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        Long memberId = Long.valueOf(jwtTokenProvider.getUserPk(refreshToken));
+
+        if (!authRedisService.isValidRefreshToken(memberId, refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String role = member.getRole().name();
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(String.valueOf(memberId), role);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(String.valueOf(memberId));
+
+        authRedisService.saveRefreshToken(memberId, newRefreshToken);
+
+        return new TokenResponse(newAccessToken, newRefreshToken, role);
     }
 }

--- a/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
@@ -1,6 +1,7 @@
 package ctrlS.totori.auth.service;
 
 import ctrlS.totori.auth.dto.OAuth2Attribute;
+import ctrlS.totori.global.security.oauth.CustomOAuth2User;
 import ctrlS.totori.member.entity.LoginType;
 import ctrlS.totori.member.entity.Member;
 import ctrlS.totori.member.entity.Role;
@@ -51,10 +52,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             Member member = saveOrUpdate(attributes.providerId(), attributes.name());
 
             // Security 세션에 저장할 정보 반환
-            return new DefaultOAuth2User(
-                    Collections.singleton(new SimpleGrantedAuthority(member.getRole().name())),
+            return new CustomOAuth2User(
+                    member.getId(),
+                    member.getRole().name(),
                     attributes.attributes(),
-                    attributes.nameAttributeKey()
+                    userNameAttributeName
             );
         } finally {
             session.removeAttribute("SOCIAL_LOGIN_ROLE");

--- a/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
@@ -42,10 +42,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         // 서비스 구분
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        String userNameAttributeName = userRequest.getClientRegistration()
-                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
 
-        OAuth2Attribute attributes = OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+        OAuth2Attribute attributes = OAuth2Attribute.of(registrationId, oAuth2User.getAttributes());
 
         try {
             // 저장(여기서 Role 결정)
@@ -55,8 +53,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             return new CustomOAuth2User(
                     member.getId(),
                     member.getRole().name(),
-                    attributes.attributes(),
-                    userNameAttributeName
+                    attributes.attributes()
             );
         } finally {
             session.removeAttribute("SOCIAL_LOGIN_ROLE");

--- a/src/main/java/ctrlS/totori/badge/controller/BadgeController.java
+++ b/src/main/java/ctrlS/totori/badge/controller/BadgeController.java
@@ -28,13 +28,13 @@ public class BadgeController {
     // 유저의 뱃지 조회
     @GetMapping("/my")
     public ResponseEntity<List<MemberBadgeResponseDto>> getMemberBadges(@AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ResponseEntity.ok(badgeService.getMemberBadges(principal.getMemberId()));
+        return ResponseEntity.ok(badgeService.getMemberBadges(principal.memberId()));
     }
 
     // 대표 뱃지 조회
     @GetMapping("/my/representative")
     public ResponseEntity<MemberBadgeResponseDto> getRepresentativeBadge(@AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ResponseEntity.ok(badgeService.getRepresentativeBadge(principal.getMemberId()));
+        return ResponseEntity.ok(badgeService.getRepresentativeBadge(principal.memberId()));
     }
 
     // 특정 카테고리의 상세 뱃지 정보 조회
@@ -42,6 +42,6 @@ public class BadgeController {
     public ResponseEntity<CategoryBadgeResponseDto> getCategoryBadgeDetails(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable BadgeCategory category) {
-        return ResponseEntity.ok(badgeService.getCategoryBadgeDetail(principal.getMemberId(), category));
+        return ResponseEntity.ok(badgeService.getCategoryBadgeDetail(principal.memberId(), category));
     }
 }

--- a/src/main/java/ctrlS/totori/book/controller/BookController.java
+++ b/src/main/java/ctrlS/totori/book/controller/BookController.java
@@ -38,6 +38,6 @@ public class BookController {
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody BookGenerateRequest request
             ) {
-        return ResponseEntity.ok(bookService.generateBook(principal.getMemberId(), request));
+        return ResponseEntity.ok(bookService.generateBook(principal.memberId(), request));
     }
 }

--- a/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
+++ b/src/main/java/ctrlS/totori/global/config/SecurityConfig.java
@@ -16,6 +16,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import java.time.LocalDateTime;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -43,9 +45,12 @@ public class SecurityConfig {
                             response.setContentType("application/json;charset=UTF-8");
                             response.getWriter().write(
                                     String.format(
-                                            "{\"status\":%d,\"message\":\"%s\"}",
+                                            "{\"timestamp\":\"%s\",\"status\":%d,\"errorCode\":\"%s\",\"message\":\"%s\",\"path\":\"%s\"}",
+                                            LocalDateTime.now(),
                                             ErrorCode.UNAUTHORIZED_ACCESS.getStatus(),
-                                            ErrorCode.UNAUTHORIZED_ACCESS.getMessage()
+                                            ErrorCode.UNAUTHORIZED_ACCESS.name(),
+                                            ErrorCode.UNAUTHORIZED_ACCESS.getMessage(),
+                                            request.getRequestURI()
                                     )
                             );
                         })
@@ -54,9 +59,12 @@ public class SecurityConfig {
                             response.setContentType("application/json;charset=UTF-8");
                             response.getWriter().write(
                                     String.format(
-                                            "{\"status\":%d,\"message\":\"%s\"}",
+                                            "{\"timestamp\":\"%s\",\"status\":%d,\"errorCode\":\"%s\",\"message\":\"%s\",\"path\":\"%s\"}",
+                                            LocalDateTime.now(),
                                             ErrorCode.ACCESS_DENIED.getStatus(),
-                                            ErrorCode.ACCESS_DENIED.getMessage()
+                                            ErrorCode.ACCESS_DENIED.name(),
+                                            ErrorCode.ACCESS_DENIED.getMessage(),
+                                            request.getRequestURI()
                                     )
                             );
                         })

--- a/src/main/java/ctrlS/totori/global/security/CustomUserPrincipal.java
+++ b/src/main/java/ctrlS/totori/global/security/CustomUserPrincipal.java
@@ -1,11 +1,6 @@
 package ctrlS.totori.global.security;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import ctrlS.totori.member.entity.Role;
 
-@Getter
-@RequiredArgsConstructor
-public class CustomUserPrincipal {
-    private final Long memberId;
-    private final String role;
+public record CustomUserPrincipal(Long memberId, Role role) {
 }

--- a/src/main/java/ctrlS/totori/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/ctrlS/totori/global/security/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package ctrlS.totori.global.security;
 import ctrlS.totori.auth.service.AuthRedisService;
 import ctrlS.totori.global.exception.ErrorCode;
 import ctrlS.totori.global.util.RedisUtil;
+import ctrlS.totori.member.entity.Role;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,7 +45,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Long memberId = Long.valueOf(jwtTokenProvider.getUserPk(token));
             String role = jwtTokenProvider.getRole(token);
 
-            CustomUserPrincipal principal = new CustomUserPrincipal(memberId, role);
+            CustomUserPrincipal principal = new CustomUserPrincipal(memberId, Role.valueOf(role));
 
             var authorities = List.of(new SimpleGrantedAuthority(role));
             var authentication = new UsernamePasswordAuthenticationToken(principal, null, authorities);

--- a/src/main/java/ctrlS/totori/global/security/JwtTokenProvider.java
+++ b/src/main/java/ctrlS/totori/global/security/JwtTokenProvider.java
@@ -17,15 +17,16 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private final SecretKey key;
-    private final long validTime = 30 * 60 * 1000L; // 30분
+    private final long accessTokenValidTime = 30 * 60 * 1000L; // 30분
+    private final long refreshTokenValidTime = 14 * 24 * 60 * 60 * 1000L; // 14일
 
     public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
         this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
     }
 
-    public String createToken(String userPk, String role) {
+    public String createAccessToken(String userPk, String role) {
         Date now = new Date();
-        Date expiration = new Date(now.getTime() + validTime);
+        Date expiration = new Date(now.getTime() + accessTokenValidTime);
 
         return Jwts.builder()
                 .subject(userPk) // 토큰 주인(회원 ID)
@@ -33,6 +34,19 @@ public class JwtTokenProvider {
                 .issuedAt(now) // 발행 시간
                 .expiration(expiration) // 만료 시간
                 .signWith(key) // 키로 암호화
+                .compact();
+    }
+
+    // refresh token 발급
+    public String createRefreshToken(String userPk) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + refreshTokenValidTime);
+
+        return Jwts.builder()
+                .subject(userPk)
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(key)
                 .compact();
     }
 

--- a/src/main/java/ctrlS/totori/global/security/oauth/CustomOAuth2User.java
+++ b/src/main/java/ctrlS/totori/global/security/oauth/CustomOAuth2User.java
@@ -1,0 +1,40 @@
+package ctrlS.totori.global.security.oauth;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+    private final Long memberId;
+    private final String role;
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
+
+    public CustomOAuth2User(Long memberId, String role, Map<String, Object> attributes, String nameAttributeKey) {
+        this.memberId = memberId;
+        this.role = role;
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role));
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(memberId);
+    }
+}

--- a/src/main/java/ctrlS/totori/global/security/oauth/CustomOAuth2User.java
+++ b/src/main/java/ctrlS/totori/global/security/oauth/CustomOAuth2User.java
@@ -14,13 +14,11 @@ public class CustomOAuth2User implements OAuth2User {
     private final Long memberId;
     private final String role;
     private final Map<String, Object> attributes;
-    private final String nameAttributeKey;
 
-    public CustomOAuth2User(Long memberId, String role, Map<String, Object> attributes, String nameAttributeKey) {
+    public CustomOAuth2User(Long memberId, String role, Map<String, Object> attributes) {
         this.memberId = memberId;
         this.role = role;
         this.attributes = attributes;
-        this.nameAttributeKey = nameAttributeKey;
     }
 
     @Override

--- a/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
@@ -23,12 +23,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         // 로그인된 사용자 정보 꺼내기
-        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-        String targetId = authentication.getName();
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        String memberId = String.valueOf(oAuth2User.getMemberId());
         String role = oAuth2User.getAuthorities().iterator().next().getAuthority();
 
         // JWT 토큰 생성
-        String token = jwtTokenProvider.createToken(targetId, role);
+        String token = jwtTokenProvider.createToken(memberId, role);
 
         // 앱으로 리다이렉트할 주소 만들기(임의로 localhost로 보냄)
         // todo: 앱 연동 시 실제 서비스 도메인으로 redirect URL 변경

--- a/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
@@ -1,5 +1,6 @@
 package ctrlS.totori.global.security.oauth;
 
+import ctrlS.totori.auth.service.AuthRedisService;
 import ctrlS.totori.global.security.JwtTokenProvider;
 import ctrlS.totori.member.entity.Member;
 import jakarta.servlet.ServletException;
@@ -19,6 +20,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthRedisService authRedisService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -28,13 +30,16 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String role = oAuth2User.getAuthorities().iterator().next().getAuthority();
 
         // JWT 토큰 생성
-        String token = jwtTokenProvider.createToken(memberId, role);
+        String accessToken = jwtTokenProvider.createAccessToken(memberId, role);
+        String refreshToken = jwtTokenProvider.createRefreshToken(memberId);
+
+        authRedisService.saveRefreshToken(Long.valueOf(memberId), refreshToken);
 
         // 앱으로 리다이렉트할 주소 만들기(임의로 localhost로 보냄)
         // todo: 앱 연동 시 실제 서비스 도메인으로 redirect URL 변경
-        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:8080/login/success")
-                .queryParam("token", token)
-                .build().toUriString();
+        String targetUrl = String.format(
+                "/login/success?accessToken=%s&refreshToken=%s&role=%s",
+                accessToken, refreshToken, role);
 
         // 리다이렉트 수행
         getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/ctrlS/totori/global/util/RedisUtil.java
+++ b/src/main/java/ctrlS/totori/global/util/RedisUtil.java
@@ -28,4 +28,8 @@ public class RedisUtil {
     public boolean hasKey(String key) {
         return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
     }
+
+    public void deleteDate(String key) {
+        stringRedisTemplate.delete(key);
+    }
 }

--- a/src/main/java/ctrlS/totori/global/util/RedisUtil.java
+++ b/src/main/java/ctrlS/totori/global/util/RedisUtil.java
@@ -29,7 +29,7 @@ public class RedisUtil {
         return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
     }
 
-    public void deleteDate(String key) {
+    public void deleteData(String key) {
         stringRedisTemplate.delete(key);
     }
 }

--- a/src/main/java/ctrlS/totori/member/controller/ConnectController.java
+++ b/src/main/java/ctrlS/totori/member/controller/ConnectController.java
@@ -34,7 +34,7 @@ public class ConnectController {
     })
     @PostMapping("/code")
     public ResponseEntity<ConnectCodeResponse> createCode(@AuthenticationPrincipal CustomUserPrincipal principal) {
-        String code = connectService.createConnectCode(principal.getMemberId());
+        String code = connectService.createConnectCode(principal.memberId());
 
         return ResponseEntity.ok(new ConnectCodeResponse(code, 600));
     }
@@ -48,7 +48,7 @@ public class ConnectController {
     public ResponseEntity<Void> linkChild(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody ConnectRequest request) {
-        connectService.connectToChild(principal.getMemberId(), request);
+        connectService.connectToChild(principal.memberId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/ctrlS/totori/member/controller/MemberController.java
+++ b/src/main/java/ctrlS/totori/member/controller/MemberController.java
@@ -35,7 +35,7 @@ public class MemberController {
     })
     @GetMapping("/me")
     public ResponseEntity<MemberMeResponse> getMyInfo(@AuthenticationPrincipal CustomUserPrincipal principal) {
-        return ResponseEntity.ok(memberService.getMyInfo(principal.getMemberId()));
+        return ResponseEntity.ok(memberService.getMyInfo(principal.memberId()));
     }
 
     // 회원 도토리 개수 조회
@@ -48,7 +48,7 @@ public class MemberController {
     public ResponseEntity<AcornResponse> getMyAcorn(
             @AuthenticationPrincipal CustomUserPrincipal principal
     ) {
-        return ResponseEntity.ok(memberService.getMyAcorn(principal.getMemberId()));
+        return ResponseEntity.ok(memberService.getMyAcorn(principal.memberId()));
     }
 
     // 회원 정보 수정
@@ -63,7 +63,7 @@ public class MemberController {
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestBody @Valid UpdateMemberRequest request
             ) {
-        return ResponseEntity.ok(memberService.updateMyInfo(principal.getMemberId(), request));
+        return ResponseEntity.ok(memberService.updateMyInfo(principal.memberId(), request));
     }
 
     // 회원 탈퇴
@@ -77,7 +77,7 @@ public class MemberController {
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @RequestHeader("Authorization") String bearerToken
     ) {
-        memberService.deleteMyAccount(principal.getMemberId(), bearerToken);
+        memberService.deleteMyAccount(principal.memberId(), bearerToken);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/ctrlS/totori/report/controller/ReportController.java
+++ b/src/main/java/ctrlS/totori/report/controller/ReportController.java
@@ -29,7 +29,7 @@ public class ReportController {
     })
     @GetMapping("/week")
     public ResponseEntity<WeeklyReportResponse> getWeeklyReport(@AuthenticationPrincipal CustomUserPrincipal principal){
-        WeeklyReportResponse response = reportService.getWeeklyReport(principal.getMemberId());
+        WeeklyReportResponse response = reportService.getWeeklyReport(principal.memberId());
         return ResponseEntity.ok(response);
     }
 
@@ -39,7 +39,7 @@ public class ReportController {
     })
     @GetMapping("/total")
     public ResponseEntity<TotalReportResponse> getTotalReport(@AuthenticationPrincipal CustomUserPrincipal principal){
-        TotalReportResponse response = reportService.getTotalReport(principal.getMemberId());
+        TotalReportResponse response = reportService.getTotalReport(principal.memberId());
         return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- JWT refresh token 기반 토큰 재발급 로직 구현했습니다.

## 📍 변경 사항
Create: CustomOAuth2User
Update: AuthController, CustomOAuth2UserService, JwtAuthenticationFilter, OAuth2SuccessHandler, TokenResponse, AuthRedisService, AuthService, JwtTokenProvider, OAuth2SuccessHandler, RedisUtil, BadgeController, BookController, CustomUserPrincipdal, ConnectController, MemberController, ReportController
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
- 문제: : 카카오 로그인 시 authentication.getName()이 카카오 provider ID를 반환해 일반 로그인의 DB member PK와 불일치했습니다.
해결: CustomOAuth2User를 도입해 getName()이 DB member PK를 반환하도록 통일했습니다.

## 🔍 참고 사항
로그인 시 다음과 같이 Access Token과 Refresh Token, Role이 반환됩니다. 
Refresh Token의 유효 기간은 14일로 설정하였습니다.
<img width="628" height="273" alt="스크린샷 2026-04-04 오후 4 29 25" src="https://github.com/user-attachments/assets/c427a7d4-d035-4aa5-8667-447ee675c4ee" />


## ✨ 관련 이슈
- closes #48 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
