### PR TITLE
[Hotfix] 동화 이미지 조회마다 presignedUrl 부여

### DIFF
--- a/src/main/java/ctrlS/totori/book/dto/summary/BookCardSummary.java
+++ b/src/main/java/ctrlS/totori/book/dto/summary/BookCardSummary.java
@@ -11,7 +11,7 @@ public record BookCardSummary(
         boolean hasBadge
 
 ) {
-    public static BookCardSummary of(Book book, BookReadingRecord recentRecord) {
+    public static BookCardSummary of(Book book, BookReadingRecord recentRecord, String presignedUrl) {
         double progress = 0.0;
         boolean hasBadge = false;
         if (recentRecord != null) {
@@ -24,7 +24,7 @@ public record BookCardSummary(
         return new BookCardSummary(
                 book.getId(),
                 book.getTitle(),
-                book.getCoverImageUrl(),
+                presignedUrl,
                 progress,
                 hasBadge
         );

--- a/src/main/java/ctrlS/totori/book/dto/summary/BookCoverSummary.java
+++ b/src/main/java/ctrlS/totori/book/dto/summary/BookCoverSummary.java
@@ -12,7 +12,7 @@ public record BookCoverSummary(
         int totalPage,
         double progress
 ) {
-    public static BookCoverSummary of(Book book, BookReadingRecord recentRecord) {
+    public static BookCoverSummary of(Book book, BookReadingRecord recentRecord, String presignedCoverUrl) {
         double progress = 0.0;
         if (recentRecord != null) {
             if (book.getTotalPages() > 0) {
@@ -23,7 +23,7 @@ public record BookCoverSummary(
         return new BookCoverSummary(
                 book.getId(),
                 book.getTitle(),
-                book.getCoverImageUrl(),
+                presignedCoverUrl,
                 book.getReceivedAcorn(),
                 recentRecord.getReadPages(),
                 book.getTotalPages(),

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -110,7 +110,12 @@ public class BookService {
         // TODO: 레벨테스트 연결 시 없으면 에러처리하도록 수정
         BookReadingRecord latestRecord = bookReadingRecordRepository.findLatestRecord(memberId)
                 .orElse(null);
-        BookCoverSummary currentBookDto = BookCoverSummary.of(latestRecord.getBook(), latestRecord);
+
+        String presignedCoverUrl = latestRecord != null && latestRecord.getBook().getCoverImageUrl() != null
+                ? s3ImageStorageService.getPresignedUrl(latestRecord.getBook().getCoverImageUrl())
+                : null;
+
+        BookCoverSummary currentBookDto = BookCoverSummary.of(latestRecord.getBook(), latestRecord, presignedCoverUrl);
 
         // 대표 뱃지 조회
         MemberBadgeResponseDto badgeDto = badgeService.getRepresentativeBadge(memberId);
@@ -129,9 +134,12 @@ public class BookService {
                 .stream()
                 .collect(Collectors.toMap(r -> r.getBook().getId(), r -> r));
 
-        Page<BookCardSummary> summaryPage = bookPage.map(book ->
-                BookCardSummary.of(book, latestRecordMap.get(book.getId()))
-        );
+        Page<BookCardSummary> summaryPage = bookPage.map(book -> {
+                String presignedCoverUrl = book.getCoverImageUrl() != null
+                ? s3ImageStorageService.getPresignedUrl(book.getCoverImageUrl())
+                : null;
+                return BookCardSummary.of(book, latestRecordMap.get(book.getId()), presignedCoverUrl);
+        });
         return BookListResponse.of(summaryPage);
     }
 


### PR DESCRIPTION
## 🐣 작업 개요
> 이미지 조회 시 presignedUrl을 부여합니다. 

## 📍 변경 사항
BookService
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
이렇게 로직마다 url을 부여해야하는게 맞는건지 잘 모르겠는데 일단 추가했습니다. 

## 🔍 참고 사항


## ✨ 관련 이슈
- (ex) closes #62 

## 🔧 변경 유형
* [X] Bug Fix (fix)
* [ ] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [ ] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
