### PR TITLE
[Feat] 출석 체크 기능 구현

### DIFF
--- a/src/main/java/ctrlS/totori/attendance/controller/AttendanceController.java
+++ b/src/main/java/ctrlS/totori/attendance/controller/AttendanceController.java
@@ -1,0 +1,39 @@
+package ctrlS.totori.attendance.controller;
+
+import ctrlS.totori.attendance.dto.AttendanceResponse;
+import ctrlS.totori.attendance.service.AttendanceService;
+import ctrlS.totori.global.response.dto.BaseResponse;
+import ctrlS.totori.global.security.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "출석 API")
+@RestController
+@RequestMapping("/api/child/attendance")
+@RequiredArgsConstructor
+public class AttendanceController {
+
+    private final AttendanceService attendanceService;
+
+    @Operation(summary = "출석 체크", description = "현재 로그인한 아동의 출석을 체크합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "출석 체크 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AttendanceResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하는 사용자가 없습니다.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하는 스탯이 없습니다.", content = @Content)
+    })
+    @PostMapping
+    public BaseResponse<AttendanceResponse> checkAttendance(
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        return BaseResponse.ok(attendanceService.checkAttendance(principal.memberId()));
+    }
+}

--- a/src/main/java/ctrlS/totori/attendance/controller/AttendanceController.java
+++ b/src/main/java/ctrlS/totori/attendance/controller/AttendanceController.java
@@ -29,7 +29,6 @@ public class AttendanceController {
             @ApiResponse(responseCode = "200", description = "출석 체크 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AttendanceResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.", content = @Content),
             @ApiResponse(responseCode = "404", description = "존재하는 사용자가 없습니다.", content = @Content),
-            @ApiResponse(responseCode = "404", description = "존재하는 스탯이 없습니다.", content = @Content)
     })
     @PostMapping
     public BaseResponse<AttendanceResponse> checkAttendance(

--- a/src/main/java/ctrlS/totori/attendance/dto/AttendanceResponse.java
+++ b/src/main/java/ctrlS/totori/attendance/dto/AttendanceResponse.java
@@ -1,10 +1,10 @@
 package ctrlS.totori.attendance.dto;
 
 public record AttendanceResponse(
-        boolean attendedToday,
+        boolean newlyAttended, // 오늘 처음 출석하면 true, 아니면 false
         int totalAttendanceDays
 ) {
-    public static AttendanceResponse of(boolean attendedToday, int totalAttendanceDays) {
-        return new AttendanceResponse(attendedToday, totalAttendanceDays);
+    public static AttendanceResponse of(boolean newlyAttended, int totalAttendanceDays) {
+        return new AttendanceResponse(newlyAttended, totalAttendanceDays);
     }
 }

--- a/src/main/java/ctrlS/totori/attendance/dto/AttendanceResponse.java
+++ b/src/main/java/ctrlS/totori/attendance/dto/AttendanceResponse.java
@@ -1,0 +1,10 @@
+package ctrlS.totori.attendance.dto;
+
+public record AttendanceResponse(
+        boolean attendedToday,
+        int totalAttendanceDays
+) {
+    public static AttendanceResponse of(boolean attendedToday, int totalAttendanceDays) {
+        return new AttendanceResponse(attendedToday, totalAttendanceDays);
+    }
+}

--- a/src/main/java/ctrlS/totori/attendance/service/AttendanceService.java
+++ b/src/main/java/ctrlS/totori/attendance/service/AttendanceService.java
@@ -1,0 +1,51 @@
+package ctrlS.totori.attendance.service;
+
+import ctrlS.totori.attendance.dto.AttendanceResponse;
+import ctrlS.totori.badge.entity.BadgeCategory;
+import ctrlS.totori.badge.service.BadgeService;
+import ctrlS.totori.global.exception.CustomException;
+import ctrlS.totori.global.exception.ErrorCode;
+import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.entity.MemberStat;
+import ctrlS.totori.member.repository.MemberRepository;
+import ctrlS.totori.member.repository.MemberStatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceService {
+    private final MemberRepository memberRepository;
+    private final MemberStatRepository memberStatRepository;
+    private final BadgeService badgeService;
+
+    @Transactional
+    public AttendanceResponse checkAttendance(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        MemberStat stat = memberStatRepository.findByMember(member)
+                .orElseThrow(() -> new CustomException(ErrorCode.STAT_NOT_FOUND));
+
+        LocalDate today = LocalDate.now();
+
+        if (!stat.canAttendToday(today)) {
+            return AttendanceResponse.of(
+                    false,
+                    stat.getTotalAttendanceDays()
+            );
+        }
+
+        stat.attend(today);
+
+        badgeService.checkAndGrantBadge(memberId, BadgeCategory.ATTENDANCE);
+
+        return AttendanceResponse.of(
+                true,
+                stat.getTotalAttendanceDays()
+        );
+    }
+}

--- a/src/main/java/ctrlS/totori/auth/service/AuthService.java
+++ b/src/main/java/ctrlS/totori/auth/service/AuthService.java
@@ -2,15 +2,15 @@ package ctrlS.totori.auth.service;
 
 import ctrlS.totori.global.exception.CustomException;
 import ctrlS.totori.global.exception.ErrorCode;
-import ctrlS.totori.global.util.RedisUtil;
 import ctrlS.totori.member.entity.LoginType;
 import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.entity.MemberStat;
 import ctrlS.totori.member.repository.MemberRepository;
 import ctrlS.totori.auth.dto.LoginRequest;
 import ctrlS.totori.auth.dto.SignUpRequest;
 import ctrlS.totori.auth.dto.TokenResponse;
 import ctrlS.totori.global.security.JwtTokenProvider;
-import jakarta.servlet.http.HttpSession;
+import ctrlS.totori.member.repository.MemberStatRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,12 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthService {
     private final MemberRepository memberRepository;
+    private final MemberStatRepository memberStatRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthRedisService authRedisService;
 
     @Transactional
-    public Long signUp(SignUpRequest request) {
+    public void signUp(SignUpRequest request) {
         // 아이디 중복 검사
         if (memberRepository.existsByLoginId(request.getLoginId())) {
             throw new CustomException(ErrorCode.DUPLICATE_LOGIN_ID);
@@ -43,8 +44,9 @@ public class AuthService {
                 .loginType(LoginType.NATIVE)
                 .build();
 
-        // DB에 저장하고 회원 고유 Id 반환
-        return memberRepository.save(member).getId();
+        // DB에 저장
+        Member savedMember = memberRepository.save(member);
+        memberStatRepository.save(MemberStat.builder().member(savedMember).build());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/ctrlS/totori/auth/service/CustomOAuth2UserService.java
@@ -4,8 +4,10 @@ import ctrlS.totori.auth.dto.OAuth2Attribute;
 import ctrlS.totori.global.security.oauth.CustomOAuth2User;
 import ctrlS.totori.member.entity.LoginType;
 import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.entity.MemberStat;
 import ctrlS.totori.member.entity.Role;
 import ctrlS.totori.member.repository.MemberRepository;
+import ctrlS.totori.member.repository.MemberStatRepository;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +32,7 @@ import java.util.Optional;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final MemberRepository memberRepository;
+    private final MemberStatRepository memberStatRepository;
     private final HttpSession session;
 
     @Override
@@ -90,6 +93,9 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 .loginType(LoginType.KAKAO)
                 .build();
 
-        return memberRepository.save(member);
+        Member savedMember = memberRepository.save(member);
+        memberStatRepository.save(MemberStat.builder().member(savedMember).build());
+
+        return savedMember;
     }
 }

--- a/src/main/java/ctrlS/totori/badge/entity/BadgeCategory.java
+++ b/src/main/java/ctrlS/totori/badge/entity/BadgeCategory.java
@@ -1,6 +1,5 @@
 package ctrlS.totori.badge.entity;
 
-import ctrlS.totori.member.entity.Member;
 import ctrlS.totori.member.entity.MemberStat;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +11,7 @@ import java.util.function.Function;
 public enum BadgeCategory {
     BOOK_CREATED("상상력의 마법사", MemberStat::getTotalCreatedBooks),
     BOOK_READ("지혜의 수집가", MemberStat::getTotalReadBooks),
-    ATTENDANCE("숲속의 단골손님", MemberStat::getConsecutiveAttendanceDays),
+    ATTENDANCE("숲속의 단골손님", MemberStat::getTotalAttendanceDays),
     ACORN("도토리 부자", MemberStat::getTotalAcquiredAcorn);
 
     private final String title;

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -13,7 +13,6 @@ public enum ErrorCode {
 
     // Member
     STAT_NOT_FOUND(404, "사용자의 통계 정보를 찾을 수 없습니다."),
-    // user
     USER_NOT_FOUND(404, "존재하는 사용자가 없습니다."),
     FORBIDDEN_CHILD_ONLY(403, "아동 회원만 사용 가능합니다."),
     INVALID_ROLE(403, "유효하지 않은 역할입니다."),

--- a/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/ctrlS/totori/global/security/oauth/OAuth2SuccessHandler.java
@@ -2,19 +2,15 @@ package ctrlS.totori.global.security.oauth;
 
 import ctrlS.totori.auth.service.AuthRedisService;
 import ctrlS.totori.global.security.JwtTokenProvider;
-import ctrlS.totori.member.entity.Member;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/ctrlS/totori/member/entity/MemberStat.java
+++ b/src/main/java/ctrlS/totori/member/entity/MemberStat.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,6 +32,8 @@ public class MemberStat extends BaseTimeEntity {
     @Column(nullable = false)
     private int totalAttendanceDays = 0; // 누적 출석일
 
+    private LocalDate lastAttendedDate; // 마지막 출석일
+
     @Column(nullable = false)
     private int totalAcquiredAcorn = 0; // 누적 획득 도토리
 
@@ -50,7 +54,12 @@ public class MemberStat extends BaseTimeEntity {
         this.totalAcquiredAcorn += amount;
     }
 
-    public void attend(boolean isConsecutive) {
+    public boolean canAttendToday(LocalDate today) {
+        return lastAttendedDate == null || !lastAttendedDate.isEqual(today);
+    }
+
+    public void attend(LocalDate today) {
         this.totalAttendanceDays++;
+        this.lastAttendedDate = today;
     }
 }

--- a/src/main/java/ctrlS/totori/member/entity/MemberStat.java
+++ b/src/main/java/ctrlS/totori/member/entity/MemberStat.java
@@ -28,9 +28,6 @@ public class MemberStat extends BaseTimeEntity {
     private int totalReadBooks = 0;
 
     @Column(nullable = false)
-    private int consecutiveAttendanceDays = 0; // 연속 출석일
-
-    @Column(nullable = false)
     private int totalAttendanceDays = 0; // 누적 출석일
 
     @Column(nullable = false)
@@ -55,10 +52,5 @@ public class MemberStat extends BaseTimeEntity {
 
     public void attend(boolean isConsecutive) {
         this.totalAttendanceDays++;
-        if (isConsecutive) {
-            this.consecutiveAttendanceDays++;
-        } else {
-            this.consecutiveAttendanceDays = 1;
-        }
     }
 }


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 아동의 출석 체크 기능을 구현했습니다.
- 출석은 로그인/토큰 재발급 로직과 분리하여 별도 API로 처리하도록 구성했고, 하루 1회만 출석이 반영되도록 구현했습니다.

## 📍 변경 사항
Create: AttendanceController, AttendanceResponse, AttendanceService
Update: AuthService, CustomOAuth2UserService, MemberStat, BadgeCategory, ErrorCode, OAuth2SuccessHandler
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
- 문제: 회원가입 직후 출석 체크 시 STAT_NOT_FOUND 예외가 발생했습니다.
해결: 회원가입 시 회원 생성과 함께 MemberStat 정보도 저장하도록 수정했습니다.
- 문제: 이미 출석한 경우를 예외로 처리할지 고민했습니다.
해결: 중복 출석은 비정상 요청이 아니라 정상적인 상태라고 판단해 예외 대신 newlyAttended = false로 응답하도록 구현했습니다.

## 🔍 참고 사항
<img width="660" height="616" alt="스크린샷 2026-04-18 오후 5 07 08" src="https://github.com/user-attachments/assets/79ac3688-35d0-468d-abec-70e7f9a888be" />



## ✨ 관련 이슈
- closes #66 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [x] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
