### PR TITLE
[Fix] S3 경로 Prefix 처리 및 뱃지 이미지 연동

### DIFF
--- a/src/main/java/ctrlS/totori/badge/dto/BadgeResponseDto.java
+++ b/src/main/java/ctrlS/totori/badge/dto/BadgeResponseDto.java
@@ -12,7 +12,7 @@ public record BadgeResponseDto(
         int targetValue,
         String imageUrl
 ) {
-    public static BadgeResponseDto from(Badge badge) {
+    public static BadgeResponseDto from(Badge badge, String badgeImage) {
         return new BadgeResponseDto(
                 badge.getId(),
                 badge.getCategory(),
@@ -20,7 +20,7 @@ public record BadgeResponseDto(
                 badge.getName(),
                 badge.getLevel(),
                 badge.getTargetValue(),
-                badge.getImageUrl()
+                badgeImage
         );
     }
 

--- a/src/main/java/ctrlS/totori/badge/dto/CategoryBadgeResponseDto.java
+++ b/src/main/java/ctrlS/totori/badge/dto/CategoryBadgeResponseDto.java
@@ -19,13 +19,13 @@ public record CategoryBadgeResponseDto(
             String imageUrl,
             boolean isAcquired
     ) {
-        public static BadgeDetailDto from(Badge badge, boolean isAcquired) {
+        public static BadgeDetailDto from(Badge badge, boolean isAcquired, String badgeImage) {
             return new BadgeDetailDto(
                     badge.getId(),
                     badge.getName(),
                     badge.getLevel(),
                     badge.getTargetValue(),
-                    badge.getImageUrl(),
+                    badgeImage,
                     isAcquired
             );
         }

--- a/src/main/java/ctrlS/totori/badge/dto/MemberBadgeResponseDto.java
+++ b/src/main/java/ctrlS/totori/badge/dto/MemberBadgeResponseDto.java
@@ -9,10 +9,10 @@ public record MemberBadgeResponseDto(
         BadgeResponseDto badgeResponseDto,
         LocalDateTime acquiredAt
 ) {
-    public static MemberBadgeResponseDto from(MemberBadge memberBadge) {
+    public static MemberBadgeResponseDto from(MemberBadge memberBadge, String badgeImage) {
         return new MemberBadgeResponseDto(
                 memberBadge.getId(),
-                BadgeResponseDto.from(memberBadge.getBadge()),
+                BadgeResponseDto.from(memberBadge.getBadge(), badgeImage),
                 memberBadge.getCreatedAt()
         );
     }

--- a/src/main/java/ctrlS/totori/badge/service/BadgeService.java
+++ b/src/main/java/ctrlS/totori/badge/service/BadgeService.java
@@ -8,7 +8,7 @@ import ctrlS.totori.badge.entity.BadgeCategory;
 import ctrlS.totori.badge.entity.MemberBadge;
 import ctrlS.totori.badge.repository.BadgeRepository;
 import ctrlS.totori.badge.repository.MemberBadgeRepository;
-import ctrlS.totori.book.service.S3ImageStorageService;
+import ctrlS.totori.book.service.image.S3ImageStorageService;
 import ctrlS.totori.global.exception.CustomException;
 import ctrlS.totori.global.exception.ErrorCode;
 import ctrlS.totori.member.entity.Member;
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/ctrlS/totori/badge/service/BadgeService.java
+++ b/src/main/java/ctrlS/totori/badge/service/BadgeService.java
@@ -8,6 +8,7 @@ import ctrlS.totori.badge.entity.BadgeCategory;
 import ctrlS.totori.badge.entity.MemberBadge;
 import ctrlS.totori.badge.repository.BadgeRepository;
 import ctrlS.totori.badge.repository.MemberBadgeRepository;
+import ctrlS.totori.book.service.S3ImageStorageService;
 import ctrlS.totori.global.exception.CustomException;
 import ctrlS.totori.global.exception.ErrorCode;
 import ctrlS.totori.member.entity.Member;
@@ -33,11 +34,17 @@ public class BadgeService {
     private final MemberBadgeRepository memberBadgeRepository;
     private final MemberRepository memberRepository;
     private final MemberStatRepository memberStatRepository;
+    private final S3ImageStorageService s3ImageStorageService;
+
+    private final static String BADGE_IMAGE_PREFIX = "badges";
 
     //전체 뱃지 조회
     public List<BadgeResponseDto> getAllBadges() {
         return badgeRepository.findAll().stream()
-                .map(BadgeResponseDto::from)
+                .map(badge -> {
+                    String presignedBadgeImg = s3ImageStorageService.getPresignedUrl(BADGE_IMAGE_PREFIX, badge.getImageUrl());
+                    return BadgeResponseDto.from(badge, presignedBadgeImg);
+                })
                 .collect(Collectors.toList());
     }
 
@@ -46,7 +53,10 @@ public class BadgeService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         return memberBadgeRepository.findAllByMember(member).stream()
-                .map(MemberBadgeResponseDto::from)
+                .map(memberBadge -> {
+                    String presignedBadgeImg = s3ImageStorageService.getPresignedUrl(BADGE_IMAGE_PREFIX, memberBadge.getBadge().getImageUrl());
+                    return MemberBadgeResponseDto.from(memberBadge, presignedBadgeImg);
+                })
                 .collect(Collectors.toList());
     }
 
@@ -111,7 +121,8 @@ public class BadgeService {
         }
 
         MemberBadge result = representativeBadge != null ? representativeBadge : myBadges.get(0);
-        return MemberBadgeResponseDto.from(result);
+        String presignedBadgeImg = s3ImageStorageService.getPresignedUrl(BADGE_IMAGE_PREFIX, result.getBadge().getImageUrl());
+        return MemberBadgeResponseDto.from(result, presignedBadgeImg);
     }
 
     // 뱃지 획득 및 레벨업 검사
@@ -140,7 +151,8 @@ public class BadgeService {
                             .build();
                     memberBadgeRepository.save(newMemberBadge);
 
-                    newlyGrantedBadges.add(BadgeResponseDto.from(badge));
+                    String presignedBadgeImg = s3ImageStorageService.getPresignedUrl(BADGE_IMAGE_PREFIX, badge.getImageUrl());
+                    newlyGrantedBadges.add(BadgeResponseDto.from(badge, presignedBadgeImg));
                 }
             } else {
                 break;
@@ -164,7 +176,8 @@ public class BadgeService {
         List<CategoryBadgeResponseDto.BadgeDetailDto> badgeDetails = new java.util.ArrayList<>();
         for (Badge badge : categoryBadges) {
             boolean isAcquired = currentCount >= badge.getTargetValue();
-            badgeDetails.add(CategoryBadgeResponseDto.BadgeDetailDto.from(badge, isAcquired));
+            String presignedBadgeImg = s3ImageStorageService.getPresignedUrl(BADGE_IMAGE_PREFIX, badge.getImageUrl());
+            badgeDetails.add(CategoryBadgeResponseDto.BadgeDetailDto.from(badge, isAcquired, presignedBadgeImg));
         }
 
         return new CategoryBadgeResponseDto(

--- a/src/main/java/ctrlS/totori/book/dto/response/BookGenerateResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/response/BookGenerateResponse.java
@@ -1,7 +1,6 @@
 package ctrlS.totori.book.dto.response;
 
 import ctrlS.totori.book.entity.Book;
-import ctrlS.totori.book.service.S3ImageStorageService;
 
 import java.util.List;
 

--- a/src/main/java/ctrlS/totori/book/dto/response/BookPageResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/response/BookPageResponse.java
@@ -1,7 +1,6 @@
 package ctrlS.totori.book.dto.response;
 
 import ctrlS.totori.book.entity.BookPage;
-import ctrlS.totori.book.service.S3ImageStorageService;
 
 import java.util.List;
 

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -43,6 +43,8 @@ public class BookService {
     private final PageImageAsyncService pageImageAsyncService;
     private final S3ImageStorageService s3ImageStorageService;
 
+    private final static String BOOK_IMAGE_PREFIX = "bookImages";
+
     public BookGenerateResponse generateBook(Long memberId, BookGenerateRequest request) {
         Member member = memberService.findById(memberId);
         BookReadingRecord latestRecord = getLatestRecord(memberId);
@@ -90,11 +92,11 @@ public class BookService {
         book.getPages().addAll(pages);
         Book savedBook = bookRepository.save(book);
 
-        String presignedCoverUrl = s3ImageStorageService.getPresignedUrl(savedBook.getCoverImageUrl());
+        String presignedCoverUrl = s3ImageStorageService.getPresignedUrl(BOOK_IMAGE_PREFIX, savedBook.getCoverImageUrl());
 
         List<BookPageResponse> pageResponses = savedBook.getPages().stream()
                 .map(page -> {
-                    String presignedPageUrl = s3ImageStorageService.getPresignedUrl(page.getImageUrl());
+                    String presignedPageUrl = s3ImageStorageService.getPresignedUrl(BOOK_IMAGE_PREFIX, page.getImageUrl());
                     return BookPageResponse.of(page, presignedPageUrl);
                 })
                 .toList();
@@ -113,7 +115,7 @@ public class BookService {
         // TODO: 레벨테스트 연결 시 수정
         if (latestRecord == null) return new MainPageResponse(AcornResponse.from(member), null, badgeDto.badgeResponseDto());
 
-        String presignedCoverUrl = s3ImageStorageService.getPresignedUrl(latestRecord.getBook().getCoverImageUrl());
+        String presignedCoverUrl = s3ImageStorageService.getPresignedUrl(BOOK_IMAGE_PREFIX, latestRecord.getBook().getCoverImageUrl());
         BookCoverSummary currentBookDto = BookCoverSummary.of(latestRecord.getBook(), latestRecord, presignedCoverUrl);
 
         return new MainPageResponse(AcornResponse.from(member), currentBookDto, badgeDto.badgeResponseDto());
@@ -131,7 +133,7 @@ public class BookService {
                 .collect(Collectors.toMap(r -> r.getBook().getId(), r -> r));
 
         Page<BookCardSummary> summaryPage = bookPage.map(book -> {
-                String presignedCoverUrl = s3ImageStorageService.getPresignedUrl(book.getCoverImageUrl());
+                String presignedCoverUrl = s3ImageStorageService.getPresignedUrl(BOOK_IMAGE_PREFIX, book.getCoverImageUrl());
                 return BookCardSummary.of(book, latestRecordMap.get(book.getId()), presignedCoverUrl);
         });
         return BookListResponse.of(summaryPage);

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -17,6 +17,8 @@ import ctrlS.totori.book.entity.BookPage;
 import ctrlS.totori.book.entity.BookReadingRecord;
 import ctrlS.totori.book.repository.BookReadingRecordRepository;
 import ctrlS.totori.book.repository.BookRepository;
+import ctrlS.totori.book.service.image.PageImageAsyncService;
+import ctrlS.totori.book.service.image.S3ImageStorageService;
 import ctrlS.totori.member.dto.response.AcornResponse;
 import ctrlS.totori.member.entity.Member;
 import ctrlS.totori.member.service.MemberService;

--- a/src/main/java/ctrlS/totori/book/service/S3ImageStorageService.java
+++ b/src/main/java/ctrlS/totori/book/service/S3ImageStorageService.java
@@ -43,15 +43,19 @@ public class S3ImageStorageService implements ImageStorageService {
         }
     }
 
-    public String getPresignedUrl(String fileName) {
+    public String getPresignedUrl(String prefix, String fileName) {
         if (fileName == null || fileName.isBlank()) {
             return null;
         }
 
         try {
+            String key = (prefix != null && !prefix.isBlank())
+                    ? prefix + "/" + fileName
+                    : fileName;
+
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                     .bucket(bucket)
-                    .key("bookImages/" + fileName)
+                    .key(key)
                     .build();
 
             GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()

--- a/src/main/java/ctrlS/totori/book/service/image/ImageStorageService.java
+++ b/src/main/java/ctrlS/totori/book/service/image/ImageStorageService.java
@@ -1,4 +1,4 @@
-package ctrlS.totori.book.service;
+package ctrlS.totori.book.service.image;
 
 public interface ImageStorageService {
     String uploadImage(byte[] imageBytes, String fileName);

--- a/src/main/java/ctrlS/totori/book/service/image/PageImageAsyncService.java
+++ b/src/main/java/ctrlS/totori/book/service/image/PageImageAsyncService.java
@@ -1,5 +1,6 @@
-package ctrlS.totori.book.service;
+package ctrlS.totori.book.service.image;
 
+import ctrlS.totori.book.service.StableDiffusionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;

--- a/src/main/java/ctrlS/totori/book/service/image/S3ImageStorageService.java
+++ b/src/main/java/ctrlS/totori/book/service/image/S3ImageStorageService.java
@@ -1,4 +1,4 @@
-package ctrlS.totori.book.service;
+package ctrlS.totori.book.service.image;
 
 import ctrlS.totori.global.exception.CustomException;
 import ctrlS.totori.global.exception.ErrorCode;
@@ -13,7 +13,6 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
-import java.awt.*;
 import java.time.Duration;
 
 @Service


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- s3 presigned 조회 메서드 prefix를 파라미터로 받도록 변경
- 뱃지 관련 이미지 로직 추가

## 📍 변경 사항
- s3ImageStorageService
- bookService, badgeService, dto들

## 🔍 참고 사항
- badge관련된 이미지 조회하려고 하니까 presigned로 변경할 때 "/bookImage" 로 시작하도록 지정되어있길래, 파라미터로 받아오도록 수정하였습니다.
- badge 이미지 insert sql 변경되었으니까 drop하고 다시 insert 해주세요~

## ✨ 관련 이슈
- closes #74

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
