### PR TITLE
[feat] 동화 상세 조회, 동화 낭독 완료 및 뱃지 부여 api 

### DIFF
--- a/src/main/java/ctrlS/totori/badge/entity/Badge.java
+++ b/src/main/java/ctrlS/totori/badge/entity/Badge.java
@@ -38,6 +38,6 @@ public class Badge {
         this.level = level;
         this.name = name;
         this.targetValue = targetValue;
-        this.imageUrl = this.imageUrl;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/ctrlS/totori/badge/service/BadgeService.java
+++ b/src/main/java/ctrlS/totori/badge/service/BadgeService.java
@@ -70,7 +70,6 @@ public class BadgeService {
         List<MemberBadge> myBadges = memberBadgeRepository.findAllByMember(member);
 
         if (myBadges.isEmpty()) {
-            //TODO: 보유한 뱃지가 없을 때 표시할 뱃지 설정하기
             throw new CustomException(ErrorCode.BADGE_NOT_FOUND);
         }
 

--- a/src/main/java/ctrlS/totori/book/controller/BookController.java
+++ b/src/main/java/ctrlS/totori/book/controller/BookController.java
@@ -1,6 +1,7 @@
 package ctrlS.totori.book.controller;
 
 import ctrlS.totori.book.dto.request.BookGenerateRequest;
+import ctrlS.totori.book.dto.response.BookDetailResponse;
 import ctrlS.totori.book.dto.response.BookGenerateResponse;
 import ctrlS.totori.book.dto.response.BookListResponse;
 import ctrlS.totori.book.dto.response.MainPageResponse;
@@ -96,5 +97,21 @@ public class BookController {
     ) {
         bookService.forwardReadingAudio(principal.memberId(), bookId, sentenceNum, audioFile);
         return BaseResponse.ok();
+    }
+
+    @Operation(summary = "동화 상세 조회", description = "특정 동화의 표지, 페이지 내용, 읽기 진행 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "동화 상세 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = BookDetailResponse.class))),
+            @ApiResponse(responseCode = "403", description = "본인의 책이 아님", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 책", content = @Content)
+    })
+    @GetMapping("/{bookId}")
+    public BaseResponse<BookDetailResponse> getBookDetail(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long bookId
+    ) {
+        return BaseResponse.ok(bookService.getBookDetail(principal.memberId(), bookId));
     }
 }

--- a/src/main/java/ctrlS/totori/book/controller/BookController.java
+++ b/src/main/java/ctrlS/totori/book/controller/BookController.java
@@ -1,10 +1,8 @@
 package ctrlS.totori.book.controller;
 
+import ctrlS.totori.book.dto.request.BookCompleteRequest;
 import ctrlS.totori.book.dto.request.BookGenerateRequest;
-import ctrlS.totori.book.dto.response.BookDetailResponse;
-import ctrlS.totori.book.dto.response.BookGenerateResponse;
-import ctrlS.totori.book.dto.response.BookListResponse;
-import ctrlS.totori.book.dto.response.MainPageResponse;
+import ctrlS.totori.book.dto.response.*;
 import ctrlS.totori.book.service.BookService;
 import ctrlS.totori.global.response.dto.BaseResponse;
 import ctrlS.totori.global.security.CustomUserPrincipal;
@@ -113,5 +111,22 @@ public class BookController {
             @PathVariable Long bookId
     ) {
         return BaseResponse.ok(bookService.getBookDetail(principal.memberId(), bookId));
+    }
+
+    @Operation(summary = "책 완독 처리", description = "책 읽기를 완료하고 획득한 뱃지를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "완독 처리 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = BookCompleteResponse.class))),
+            @ApiResponse(responseCode = "404", description = "책 또는 읽기 기록 없음", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 완독된 책", content = @Content)
+    })
+    @PostMapping("/{bookId}/complete")
+    public BaseResponse<BookCompleteResponse> completeBook(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long bookId,
+            @Valid @RequestBody BookCompleteRequest request
+    ) {
+        return BaseResponse.ok(bookService.completeBook(principal.memberId(), bookId, request));
     }
 }

--- a/src/main/java/ctrlS/totori/book/dto/request/BookCompleteRequest.java
+++ b/src/main/java/ctrlS/totori/book/dto/request/BookCompleteRequest.java
@@ -1,0 +1,12 @@
+package ctrlS.totori.book.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+@Schema(description = "책 완독 처리 요청 DTO")
+public record BookCompleteRequest(
+        @Schema(description = "이번 읽기로 획득한 도토리 개수 (0~3)")
+        @Min(0) @Max(3)
+        int acornCount
+) {}

--- a/src/main/java/ctrlS/totori/book/dto/response/BookCompleteResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/response/BookCompleteResponse.java
@@ -1,0 +1,25 @@
+package ctrlS.totori.book.dto.response;
+
+import ctrlS.totori.badge.dto.BadgeResponseDto;
+import ctrlS.totori.book.entity.Book;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "책 완독 처리 응답 DTO")
+public record BookCompleteResponse(
+        @Schema(description = "책 ID") Long bookId,
+        @Schema(description = "이번 완독으로 획득한 도토리 개수") int acornCount,
+        @Schema(description = "이 책의 누적 획득 도토리") int totalReceivedAcorn,
+        @Schema(description = "이번 완독으로 새로 획득한 뱃지 목록 (없으면 빈 배열)")
+        List<BadgeResponseDto> newlyAcquiredBadges
+) {
+    public static BookCompleteResponse of(Book book, int acornCount, List<BadgeResponseDto> newlyAcquiredBadges) {
+        return new BookCompleteResponse(
+                book.getId(),
+                acornCount,
+                book.getReceivedAcorn(),
+                newlyAcquiredBadges
+        );
+    }
+}

--- a/src/main/java/ctrlS/totori/book/dto/response/BookDetailResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/response/BookDetailResponse.java
@@ -1,0 +1,19 @@
+package ctrlS.totori.book.dto.response;
+
+import ctrlS.totori.book.dto.summary.BookCoverSummary;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "동화 상세 조회 응답 DTO")
+public record BookDetailResponse(
+        @Schema(description = "표지 정보 (제목, 표지 이미지, 도토리, 진행도 등)")
+        BookCoverSummary cover,
+
+        @Schema(description = "페이지 목록 (문장 + 이미지)")
+        List<BookPageDetailResponse> pages
+) {
+    public static BookDetailResponse of(BookCoverSummary summary, List<BookPageDetailResponse> pages) {
+        return new BookDetailResponse(summary, pages);
+    }
+}

--- a/src/main/java/ctrlS/totori/book/dto/response/BookPageDetailResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/response/BookPageDetailResponse.java
@@ -1,0 +1,23 @@
+package ctrlS.totori.book.dto.response;
+
+import ctrlS.totori.book.entity.BookPage;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "동화 상세 조회 페이지 DTO")
+public record BookPageDetailResponse(
+        @Schema(description = "페이지 ID") Long pageId,
+        @Schema(description = "페이지 순서") int pageOrder,
+        @Schema(description = "페이지 문장 목록") List<String> sentences,
+        @Schema(description = "페이지 이미지 URL (presigned)") String imageUrl
+) {
+    public static BookPageDetailResponse of(BookPage page, String presignedUrl) {
+        return new BookPageDetailResponse(
+                page.getId(),
+                page.getPageOrder(),
+                page.getSentences(),
+                presignedUrl
+        );
+    }
+}

--- a/src/main/java/ctrlS/totori/book/dto/response/BookPageDetailResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/response/BookPageDetailResponse.java
@@ -2,6 +2,7 @@ package ctrlS.totori.book.dto.response;
 
 import ctrlS.totori.book.entity.BookPage;
 import io.swagger.v3.oas.annotations.media.Schema;
+import ctrlS.totori.book.service.audio.S3AudioStorageService;
 
 import java.util.List;
 
@@ -9,14 +10,18 @@ import java.util.List;
 public record BookPageDetailResponse(
         @Schema(description = "페이지 ID") Long pageId,
         @Schema(description = "페이지 순서") int pageOrder,
-        @Schema(description = "페이지 문장 목록") List<String> sentences,
+        @Schema(description = "페이지 문장 목록") List<SentenceResponse> sentences,
         @Schema(description = "페이지 이미지 URL (presigned)") String imageUrl
 ) {
-    public static BookPageDetailResponse of(BookPage page, String presignedUrl) {
+    public static BookPageDetailResponse of(
+            BookPage page,
+            String presignedUrl,
+            List<SentenceResponse> sentences
+    ) {
         return new BookPageDetailResponse(
                 page.getId(),
                 page.getPageOrder(),
-                page.getSentences(),
+                sentences,
                 presignedUrl
         );
     }

--- a/src/main/java/ctrlS/totori/book/dto/response/BookPageResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/response/BookPageResponse.java
@@ -15,13 +15,8 @@ public record BookPageResponse(
     public static BookPageResponse of(
             BookPage page,
             String presignedImageUrl,
-            S3AudioStorageService s3AudioStorageService,
-            String audioPrefix
+            List<SentenceResponse> sentences
     ) {
-        List<SentenceResponse> sentences = page.getSentences().stream()
-                .map(s -> SentenceResponse.of(s, s3AudioStorageService, audioPrefix))
-                .toList();
-
         return new BookPageResponse(
                 page.getId(),
                 page.getPageOrder(),

--- a/src/main/java/ctrlS/totori/book/dto/summary/BookCoverSummary.java
+++ b/src/main/java/ctrlS/totori/book/dto/summary/BookCoverSummary.java
@@ -13,6 +13,7 @@ public record BookCoverSummary(
         double progress
 ) {
     public static BookCoverSummary of(Book book, BookReadingRecord recentRecord, String presignedCoverUrl) {
+        int readPages = recentRecord != null ? recentRecord.getReadPages() : 0;
         double progress = 0.0;
         if (recentRecord != null) {
             if (book.getTotalPages() > 0) {
@@ -25,7 +26,7 @@ public record BookCoverSummary(
                 book.getTitle(),
                 presignedCoverUrl,
                 book.getReceivedAcorn(),
-                recentRecord.getReadPages(),
+                readPages,
                 book.getTotalPages(),
                 progress
         );

--- a/src/main/java/ctrlS/totori/book/entity/Book.java
+++ b/src/main/java/ctrlS/totori/book/entity/Book.java
@@ -70,4 +70,8 @@ public class Book extends BaseTimeEntity {
     public boolean isFullyAcorned() {
         return this.receivedAcorn == MAX_ACORN_COUNT;
     }
+
+    public void addReceivedAcorn(int count) {
+        this.receivedAcorn = Math.min(this.receivedAcorn + count, MAX_ACORN_COUNT);
+    }
 }

--- a/src/main/java/ctrlS/totori/book/entity/BookReadingRecord.java
+++ b/src/main/java/ctrlS/totori/book/entity/BookReadingRecord.java
@@ -58,4 +58,9 @@ public class BookReadingRecord extends BaseTimeEntity {
         this.wrongWords = wrongWords != null ? wrongWords : new ArrayList<>();
         this.mistakes = mistakes != null ? mistakes : new HashMap<>();
     }
+
+    public void markAsCompleted() {
+        this.isCompleted = true;
+        this.readPages = this.book.getTotalPages();
+    }
 }

--- a/src/main/java/ctrlS/totori/book/repository/BookReadingRecordRepository.java
+++ b/src/main/java/ctrlS/totori/book/repository/BookReadingRecordRepository.java
@@ -50,4 +50,13 @@ public interface BookReadingRecordRepository extends JpaRepository<BookReadingRe
             "               WHERE r2.book.id IN :bookIds " +
             "               GROUP BY r2.book.id)")
     List<BookReadingRecord> findLatestRecordsByBookIds(@Param("bookIds") List<Long> bookIds);
+
+    // 특정 책 ID의 최신 기록 조회
+    @Query("""
+        SELECT r FROM BookReadingRecord r
+        WHERE r.book.id = :bookId
+        ORDER BY r.updatedAt DESC
+        LIMIT 1
+        """)
+    Optional<BookReadingRecord> findLatestByBookId(@Param("bookId") Long bookId);
 }

--- a/src/main/java/ctrlS/totori/book/repository/BookRepository.java
+++ b/src/main/java/ctrlS/totori/book/repository/BookRepository.java
@@ -20,4 +20,10 @@ public interface BookRepository extends JpaRepository<Book, Long> {
             ORDER BY p.pageOrder ASC
             """)
     Optional<Book> findByIdWithPages(@Param("bookId") Long bookId);
+
+    @Query("""
+        SELECT b FROM Book b
+        WHERE b.id = :bookId AND b.member.id = :memberId
+        """)
+    Optional<Book> findByIdAndMemberId(@Param("bookId") Long bookId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/ctrlS/totori/book/repository/BookRepository.java
+++ b/src/main/java/ctrlS/totori/book/repository/BookRepository.java
@@ -4,8 +4,20 @@ import ctrlS.totori.book.entity.Book;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
     // 특정 회원의 책 목록을 최신순으로 페이징 조회
     Page<Book> findAllByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
+    @Query("""
+            SELECT b FROM Book b
+            LEFT JOIN FETCH b.pages p
+            WHERE b.id = :bookId
+            ORDER BY p.pageOrder ASC
+            """)
+    Optional<Book> findByIdWithPages(@Param("bookId") Long bookId);
 }

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -36,6 +36,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import ctrlS.totori.book.entity.SentenceData;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -172,11 +173,7 @@ public class BookService {
 
         List<BookPageDetailResponse> pageResponses = book.getPages().stream()
                 .sorted(Comparator.comparingInt(BookPage::getPageOrder))
-                .map(page -> {
-                    String presignedPageUrl = s3ImageStorageService
-                            .getPresignedUrl(BOOK_IMAGE_PREFIX, page.getImageUrl());
-                    return BookPageDetailResponse.of(page, presignedPageUrl);
-                })
+                .map(this::toPageDetailResponse)  // ★ private 메서드로 위임
                 .toList();
 
         return BookDetailResponse.of(cover, pageResponses);
@@ -288,8 +285,10 @@ public class BookService {
                 .map(page -> {
                     String presignedPageUrl = s3ImageStorageService.getPresignedUrl(
                             BOOK_IMAGE_PREFIX, page.getImageUrl());
-                    return BookPageResponse.of(
-                            page, presignedPageUrl, s3AudioStorageService, BOOK_AUDIO_PREFIX);
+                    List<SentenceResponse> sentences = page.getSentences().stream()
+                            .map(this::toSentenceResponse)
+                            .toList();
+                    return BookPageResponse.of(page, presignedPageUrl, sentences);
                 })
                 .toList();
 
@@ -330,5 +329,27 @@ public class BookService {
         }
 
         return BookCompleteResponse.of(book, acornCount, newlyAcquiredBadges);
+    }
+
+    private BookPageDetailResponse toPageDetailResponse(BookPage page) {
+        String presignedImageUrl = s3ImageStorageService.getPresignedUrl(
+                BOOK_IMAGE_PREFIX, page.getImageUrl());
+
+        List<SentenceResponse> sentences = page.getSentences().stream()
+                .map(this::toSentenceResponse)  // buildAndSaveBook에서도 쓰는 메서드
+                .toList();
+
+        return BookPageDetailResponse.of(page, presignedImageUrl, sentences);
+    }
+
+    private SentenceResponse toSentenceResponse(SentenceData data) {
+        String audioUrl = s3AudioStorageService.getPresignedUrl(
+                BOOK_AUDIO_PREFIX, data.getAudioS3Key());
+
+        return new SentenceResponse(
+                data.getText(),
+                audioUrl,
+                data.getDurationMs()
+        );
     }
 }

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -146,6 +146,36 @@ public class BookService {
         );
     }
 
+    @Transactional
+    public BookDetailResponse getBookDetail(Long memberId, Long bookId) {
+        Book book = bookRepository.findByIdWithPages(bookId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
+
+        if (!book.getMember().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.BOOK_ACCESS_DENIED);
+        }
+
+        BookReadingRecord latestRecord = bookReadingRecordRepository
+                .findLatestRecord(bookId)
+                .orElse(null);
+
+        String presignedCoverUrl = s3ImageStorageService
+                .getPresignedUrl(BOOK_IMAGE_PREFIX, book.getCoverImageUrl());
+
+        BookCoverSummary cover = BookCoverSummary.of(book, latestRecord, presignedCoverUrl);
+
+        List<BookPageDetailResponse> pageResponses = book.getPages().stream()
+                .sorted(Comparator.comparingInt(BookPage::getPageOrder))
+                .map(page -> {
+                    String presignedPageUrl = s3ImageStorageService
+                            .getPresignedUrl(BOOK_IMAGE_PREFIX, page.getImageUrl());
+                    return BookPageDetailResponse.of(page, presignedPageUrl);
+                })
+                .toList();
+
+        return BookDetailResponse.of(cover, pageResponses);
+    }
+
     protected BookReadingRecord getLatestRecord(Long memberId) {
         return bookReadingRecordRepository
                 .findTopByBook_Member_IdOrderByUpdatedAtDesc(memberId)

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -1,10 +1,13 @@
 package ctrlS.totori.book.service;
 
+import ctrlS.totori.badge.dto.BadgeResponseDto;
 import ctrlS.totori.badge.dto.MemberBadgeResponseDto;
+import ctrlS.totori.badge.entity.BadgeCategory;
 import ctrlS.totori.badge.service.BadgeService;
 import ctrlS.totori.book.client.FastApiStoryClient;
 import ctrlS.totori.book.dto.fastApi.FastApiGenerateStoryRequest;
 import ctrlS.totori.book.dto.fastApi.FastApiStoryResponse;
+import ctrlS.totori.book.dto.request.BookCompleteRequest;
 import ctrlS.totori.book.dto.request.BookGenerateRequest;
 import ctrlS.totori.book.dto.response.*;
 import ctrlS.totori.book.dto.summary.BookCardSummary;
@@ -23,6 +26,8 @@ import ctrlS.totori.global.exception.CustomException;
 import ctrlS.totori.global.exception.ErrorCode;
 import ctrlS.totori.member.dto.response.AcornResponse;
 import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.entity.MemberStat;
+import ctrlS.totori.member.repository.MemberStatRepository;
 import ctrlS.totori.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +58,7 @@ public class BookService {
     private final S3ImageStorageService s3ImageStorageService;
     private final TtsService ttsService;
     private final S3AudioStorageService s3AudioStorageService;
+    private final MemberStatRepository memberStatRepository;
 
     private final static String BOOK_IMAGE_PREFIX = "bookImages";
     private final static String BOOK_AUDIO_PREFIX = "bookAudios";
@@ -263,6 +269,11 @@ public class BookService {
 
         Book savedBook = bookRepository.save(book);
 
+        MemberStat memberStat = memberStatRepository.findByMember(member)
+                .orElseThrow(() -> new CustomException(ErrorCode.STAT_NOT_FOUND));
+        memberStat.addCreatedBook();
+        badgeService.checkAndGrantBadge(member.getId(), BadgeCategory.BOOK_CREATED);
+
         try {
             ttsService.generateAllAudios(savedBook);
             bookRepository.save(savedBook);
@@ -283,5 +294,41 @@ public class BookService {
                 .toList();
 
         return BookGenerateResponse.of(savedBook, presignedCoverUrl, pageResponses);
+    }
+
+    @Transactional
+    public BookCompleteResponse completeBook(Long memberId, Long bookId, BookCompleteRequest request) {
+        Book book = bookRepository.findByIdAndMemberId(bookId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_ACCESS_DENIED));
+
+        BookReadingRecord latestRecord = bookReadingRecordRepository.findLatestByBookId(bookId)
+                .orElseThrow(() -> new CustomException(ErrorCode.READING_RECORD_NOT_EXIST));
+
+        if (latestRecord.isCompleted()) {
+            return BookCompleteResponse.of(book, 0, List.of());
+        }
+
+        latestRecord.markAsCompleted();
+
+        int acornCount = request.acornCount();
+        book.addReceivedAcorn(acornCount);
+
+        Member member = memberService.findById(memberId);
+        MemberStat memberStat = memberStatRepository.findByMember(member)
+                .orElseThrow(() -> new CustomException(ErrorCode.STAT_NOT_FOUND));
+
+        memberStat.addReadBook();
+
+        if (acornCount > 0) {
+            memberStat.addAcquiredAcorn(acornCount);
+        }
+
+        List<BadgeResponseDto> newlyAcquiredBadges = new ArrayList<>();
+        newlyAcquiredBadges.addAll(badgeService.checkAndGrantBadge(memberId, BadgeCategory.BOOK_READ));
+        if (acornCount > 0) {
+            newlyAcquiredBadges.addAll(badgeService.checkAndGrantBadge(memberId, BadgeCategory.ACORN));
+        }
+
+        return BookCompleteResponse.of(book, acornCount, newlyAcquiredBadges);
     }
 }

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     BOOK_NOT_FOUND(404, "해당 책이 존재하지 않습니다."),
     PAGE_NOT_FOUND(404, "해당 페이지가 존재하지 않습니다."),
     BOOK_ACCESS_DENIED(401, "해당 회원의 책이 아닙니다." ),
+    READING_RECORD_NOT_EXIST(404, "낭독 정보가 존재하지 않습니다."),
 
     // Badge
     BADGE_NOT_FOUND(404, "보유한 뱃지가 없습니다."),

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -27,9 +27,10 @@ public enum ErrorCode {
     EXPIRED_TOKEN(401, "만료된 토큰입니다."),
 
     // Book
-    BOOK_NOT_EXIST(401, "해당 회원이 보유하고 있는 책이 없습니다."),
+    BOOK_NOT_EXIST(404, "해당 회원이 보유하고 있는 책이 없습니다."),
     BOOK_NOT_FOUND(404, "해당 책이 존재하지 않습니다."),
     PAGE_NOT_FOUND(404, "해당 페이지가 존재하지 않습니다."),
+    BOOK_ACCESS_DENIED(401, "해당 회원의 책이 아닙니다." ),
 
     // Badge
     BADGE_NOT_FOUND(404, "보유한 뱃지가 없습니다."),


### PR DESCRIPTION
## 🐣 작업 개요
> 동화를 상세 조회하고, 동화 낭독 완료 request를 받고 부여된 뱃지를 response로 보내는 api
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
동화 낭독 완료의 경우 낭독 정보가 있어야 완료 처리가 되어서 확인을 못해보았는데요.... 잘동작하길 바랍니다. 
동화 상세 조회는 테스트 완료하였습니다. 


## 🔍 참고 사항


## ✨ 관련 이슈
- (ex) closes #38 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [X] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [X] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
