### PR TITLE
[Feat] 동화 낭독 음성 전송 api 구현

### DIFF
--- a/src/main/java/ctrlS/totori/book/client/FastApiStoryClient.java
+++ b/src/main/java/ctrlS/totori/book/client/FastApiStoryClient.java
@@ -32,7 +32,8 @@ public class FastApiStoryClient {
                 .uri("/ai/story/generate")
                 .bodyValue(request)
                 .retrieve()
-                .onStatus(HttpStatusCode::isError, clientResponse -> Mono.error(new CustomException(ErrorCode.STT_TRANSCRIBE_FAILED)))
+                .onStatus(HttpStatusCode::isError, clientResponse ->
+                        Mono.error(new CustomException(ErrorCode.STT_TRANSCRIBE_FAILED)))
                 .bodyToMono(FastApiStoryResponse.class)
                 .block();
     }
@@ -52,6 +53,25 @@ public class FastApiStoryClient {
                 .onStatus(HttpStatusCode::isError, clientResponse ->
                         Mono.error(new CustomException(ErrorCode.STT_TRANSCRIBE_FAILED)))
                 .bodyToMono(FastApiStoryResponse.class)
+                .block();
+    }
+
+    public void analyzeReading(
+            MultipartFile audioFile,
+            String originalText,
+            Long childId,
+            Long bookId,
+            String level) {
+        MultipartBodyBuilder builder = buildReadingMultipartBody(audioFile, originalText, childId, bookId, level);
+
+        fastApiSttWebClient.post()
+                .uri("/ai/reading/analyze")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData((builder.build())))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, clientResponse ->
+                        Mono.error(new CustomException(ErrorCode.STT_TRANSCRIBE_FAILED)))
+                .bodyToMono(Void.class)
                 .block();
     }
 
@@ -80,6 +100,35 @@ public class FastApiStoryClient {
             if (weakPhonemes != null && !weakPhonemes.isEmpty()) {
                 builder.part("weak_phonemes", objectMapper.writeValueAsString(weakPhonemes));
             }
+            return builder;
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.STT_FILE_READ_FAILED);
+        }
+    }
+
+    private MultipartBodyBuilder buildReadingMultipartBody(
+            MultipartFile audioFile,
+            String originalText,
+            Long childId,
+            Long bookId,
+            String level) {
+        try {
+            String filename = audioFile.getOriginalFilename();
+            MediaType contentType = MediaType.parseMediaType(audioFile.getContentType());
+
+            ByteArrayResource resource = new ByteArrayResource(audioFile.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return filename;
+                }
+            };
+
+            MultipartBodyBuilder builder = new MultipartBodyBuilder();
+            builder.part("file", resource).contentType(contentType);
+            builder.part("original_text", originalText);
+            builder.part("child_id", childId.toString());
+            builder.part("book_id", bookId.toString());
+            builder.part("level", level);
             return builder;
         } catch (IOException e) {
             throw new CustomException(ErrorCode.STT_FILE_READ_FAILED);

--- a/src/main/java/ctrlS/totori/book/controller/BookController.java
+++ b/src/main/java/ctrlS/totori/book/controller/BookController.java
@@ -83,18 +83,18 @@ public class BookController {
         return BaseResponse.ok(response);
     }
 
-    @Operation(summary = "동화 낭독 음성 분석", description = "페이지 낭독 음성을 수신하여 읽기 오류를 분석합니다.")
+    @Operation(summary = "동화 낭독 음성 전송", description = "페이지 낭독 음성을 수신하여 AI 서버로 전송합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "동화 낭독 음성 분석 성공", content = @Content)
+            @ApiResponse(responseCode = "200", description = "동화 낭독 음성 전송 성공", content = @Content)
     })
     @PostMapping(value = "/{bookId}/reading/{sentenceNum}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public BaseResponse<Void> analyzeReading(
+    public BaseResponse<Void> forwardReadingAudio(
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable Long bookId,
             @PathVariable int sentenceNum,
             @RequestPart("audio") MultipartFile audioFile
     ) {
-        bookService.analyzePageReading(principal.memberId(), bookId, sentenceNum, audioFile);
+        bookService.forwardReadingAudio(principal.memberId(), bookId, sentenceNum, audioFile);
         return BaseResponse.ok();
     }
 }

--- a/src/main/java/ctrlS/totori/book/controller/BookController.java
+++ b/src/main/java/ctrlS/totori/book/controller/BookController.java
@@ -90,8 +90,8 @@ public class BookController {
     @PostMapping(value = "/{bookId}/reading/{sentenceNum}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<Void> forwardReadingAudio(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @PathVariable Long bookId,
-            @PathVariable int sentenceNum,
+            @PathVariable("bookId") Long bookId,
+            @PathVariable("sentenceNum") int sentenceNum,
             @RequestPart("audio") MultipartFile audioFile
     ) {
         bookService.forwardReadingAudio(principal.memberId(), bookId, sentenceNum, audioFile);

--- a/src/main/java/ctrlS/totori/book/controller/BookController.java
+++ b/src/main/java/ctrlS/totori/book/controller/BookController.java
@@ -82,4 +82,19 @@ public class BookController {
         BookListResponse response = bookService.getBookList(principal.memberId(), pageable);
         return BaseResponse.ok(response);
     }
+
+    @Operation(summary = "동화 낭독 음성 분석", description = "페이지 낭독 음성을 수신하여 읽기 오류를 분석합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "동화 낭독 음성 분석 성공", content = @Content)
+    })
+    @PostMapping(value = "/{bookId}/reading/{sentenceNum}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BaseResponse<Void> analyzeReading(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable Long bookId,
+            @PathVariable int sentenceNum,
+            @RequestPart("audio") MultipartFile audioFile
+    ) {
+        bookService.analyzePageReading(principal.memberId(), bookId, sentenceNum, audioFile);
+        return BaseResponse.ok();
+    }
 }

--- a/src/main/java/ctrlS/totori/book/repository/BookPageRepository.java
+++ b/src/main/java/ctrlS/totori/book/repository/BookPageRepository.java
@@ -1,0 +1,10 @@
+package ctrlS.totori.book.repository;
+
+import ctrlS.totori.book.entity.BookPage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookPageRepository extends JpaRepository<BookPage, Long> {
+    Optional<BookPage> findByBook_idAndPageOrder(Long bookId, int pageOrder);
+}

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -117,7 +117,7 @@ public class BookService {
             Long memberId, Long bookId, int sentenceNum, MultipartFile audioFile) {
         validateAudioFile(audioFile);
 
-        Member member = memberService.findById(bookId);
+        Member member = memberService.findById(memberId);
         bookRepository.findById(bookId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
 

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -112,8 +112,8 @@ public class BookService {
         return BookListResponse.of(summaryPage);
     }
 
-    // 동화 낭독 음성 분석
-    public void analyzePageReading(
+    // 동화 낭독 음성 전송
+    public void forwardReadingAudio(
             Long memberId, Long bookId, int sentenceNum, MultipartFile audioFile) {
         validateAudioFile(audioFile);
 

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -6,15 +6,13 @@ import ctrlS.totori.book.client.FastApiStoryClient;
 import ctrlS.totori.book.dto.fastApi.FastApiGenerateStoryRequest;
 import ctrlS.totori.book.dto.fastApi.FastApiStoryResponse;
 import ctrlS.totori.book.dto.request.BookGenerateRequest;
-import ctrlS.totori.book.dto.response.BookGenerateResponse;
-import ctrlS.totori.book.dto.response.BookListResponse;
-import ctrlS.totori.book.dto.response.BookPageResponse;
-import ctrlS.totori.book.dto.response.MainPageResponse;
+import ctrlS.totori.book.dto.response.*;
 import ctrlS.totori.book.dto.summary.BookCardSummary;
 import ctrlS.totori.book.dto.summary.BookCoverSummary;
 import ctrlS.totori.book.entity.Book;
 import ctrlS.totori.book.entity.BookPage;
 import ctrlS.totori.book.entity.BookReadingRecord;
+import ctrlS.totori.book.repository.BookPageRepository;
 import ctrlS.totori.book.repository.BookReadingRecordRepository;
 import ctrlS.totori.book.repository.BookRepository;
 import ctrlS.totori.book.service.image.PageImageAsyncService;
@@ -45,12 +43,14 @@ public class BookService {
     private final BookRepository bookRepository;
     private final BadgeService badgeService;
     private final BookReadingRecordRepository bookReadingRecordRepository;
+    private final BookPageRepository bookPageRepository;
     private final FastApiStoryClient fastApiStoryClient;
     private final PageImageAsyncService pageImageAsyncService;
     private final S3ImageStorageService s3ImageStorageService;
 
     private final static String BOOK_IMAGE_PREFIX = "bookImages";
 
+    // 텍스트 기반 동화 생성
     public BookGenerateResponse generateBook(Long memberId, BookGenerateRequest request) {
         Member member = memberService.findById(memberId);
         BookReadingRecord latestRecord = getLatestRecord(memberId);
@@ -61,6 +61,7 @@ public class BookService {
         return buildAndSaveBook(member, fastApiResponse);
     }
 
+    // 관심사 음성 기반 동화 생성
     public BookGenerateResponse generateBookFromVoice(Long memberId, MultipartFile audioFile) {
         validateAudioFile(audioFile);
 
@@ -109,6 +110,32 @@ public class BookService {
                 return BookCardSummary.of(book, latestRecordMap.get(book.getId()), presignedCoverUrl);
         });
         return BookListResponse.of(summaryPage);
+    }
+
+    // 동화 낭독 음성 분석
+    public void analyzePageReading(
+            Long memberId, Long bookId, int sentenceNum, MultipartFile audioFile) {
+        validateAudioFile(audioFile);
+
+        Member member = memberService.findById(bookId);
+        bookRepository.findById(bookId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
+
+        int pageOrder = (sentenceNum - 1) / 3 + 1;
+        int sentenceIndex = (sentenceNum - 1) % 3;
+
+        BookPage page = bookPageRepository.findByBook_idAndPageOrder(bookId, pageOrder)
+                .orElseThrow(() -> new CustomException(ErrorCode.PAGE_NOT_FOUND));
+
+        String originalText = page.getSentences().get(sentenceIndex);
+
+        fastApiStoryClient.analyzeReading(
+                audioFile,
+                originalText,
+                member.getId(),
+                bookId,
+                member.getLevel().toString()
+        );
     }
 
     protected BookReadingRecord getLatestRecord(Long memberId) {

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     // Book
     BOOK_NOT_EXIST(401, "해당 회원이 보유하고 있는 책이 없습니다."),
     BOOK_NOT_FOUND(404, "해당 책이 존재하지 않습니다."),
+    PAGE_NOT_FOUND(404, "해당 페이지가 존재하지 않습니다."),
 
     // Badge
     BADGE_NOT_FOUND(404, "보유한 뱃지가 없습니다."),


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- swift로부터 받은 낭독 음성 파일을 fastapi로 전송하는 api 구현했습니다.

## 📍 변경 사항
Create: BookPageRepository
Update: BookController, BookService, FastApiStoryClient, ErrorCode
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
- 문제: pageNum을 DB pageOrder라고 생각해서 잘못된 페이지를 조회하는 문제가 있었습니다.
해결: sentenceNum(프론트 순번)을 pageOrder = (sentenceNum-1)/3+1, sentenceIndex = (sentenceNum-1)%3으로 역산해 단일 문장만 추출하도록 수정했습니다.

## 🔍 참고 사항
`/api/books/{bookId}/reading/{sentenceNum}`로 동화 id와 문장(페이지) 번호를 Path Variable에 넣고 body에 낭독 파일.m4a를 보내면 응답이 아래와 같이 나옵니다. 동화 낭독 음성에서 분석된 읽기 오류는 FastAPI Redis에 저장되고, 퀴즈 생성과 동화 낭독 완료 시 사용됩니다.
<img width="656" height="562" alt="스크린샷 2026-05-09 오전 12 57 51" src="https://github.com/user-attachments/assets/20e4af00-b8d0-47b0-a4ac-5626109bd463" />
<img width="670" height="132" alt="스크린샷 2026-05-09 오전 1 01 11" src="https://github.com/user-attachments/assets/b4d3b462-b3cc-44a7-8512-1173643f065d" />


## ✨ 관련 이슈
- closes #80 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [ ] Refactoring (refactor)
* [ ] Styling (style)
* [x] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
