### PR TITLE
[Feat] 퀴즈 api 구현

### DIFF
--- a/src/main/java/ctrlS/totori/book/entity/Book.java
+++ b/src/main/java/ctrlS/totori/book/entity/Book.java
@@ -2,6 +2,8 @@ package ctrlS.totori.book.entity;
 
 import ctrlS.totori.book.dto.fastApi.FastApiStoryResponse;
 import ctrlS.totori.global.entity.BaseTimeEntity;
+import ctrlS.totori.global.exception.CustomException;
+import ctrlS.totori.global.exception.ErrorCode;
 import ctrlS.totori.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -70,5 +72,13 @@ public class Book extends BaseTimeEntity {
 
     public boolean isFullyAcorned() {
         return this.receivedAcorn == MAX_ACORN_COUNT;
+    }
+
+    public void addAcorn() {
+        if (!isFullyAcorned()) {
+            receivedAcorn++;
+        } else {
+            throw new CustomException(ErrorCode.ACORN_COUNT_EXCEEDED);
+        }
     }
 }

--- a/src/main/java/ctrlS/totori/book/entity/Book.java
+++ b/src/main/java/ctrlS/totori/book/entity/Book.java
@@ -32,6 +32,7 @@ public class Book extends BaseTimeEntity {
 
     private String coverImageUrl;
 
+    @Column(columnDefinition = "TEXT")
     private String coverImagePrompt;
 
     @Column(nullable = false)

--- a/src/main/java/ctrlS/totori/book/entity/BookPage.java
+++ b/src/main/java/ctrlS/totori/book/entity/BookPage.java
@@ -37,7 +37,7 @@ public class BookPage extends BaseTimeEntity {
     @Column(nullable = true)
     private String imageUrl;
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String imagePrompt;
 
     @Builder

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -21,6 +21,7 @@ import ctrlS.totori.book.service.image.PageImageAsyncService;
 import ctrlS.totori.book.service.image.S3ImageStorageService;
 import ctrlS.totori.global.exception.CustomException;
 import ctrlS.totori.global.exception.ErrorCode;
+import ctrlS.totori.global.util.AudioFileValidator;
 import ctrlS.totori.member.dto.response.AcornResponse;
 import ctrlS.totori.member.entity.Member;
 import ctrlS.totori.member.service.MemberService;
@@ -53,6 +54,7 @@ public class BookService {
     private final S3ImageStorageService s3ImageStorageService;
     private final TtsService ttsService;
     private final S3AudioStorageService s3AudioStorageService;
+    private final AudioFileValidator audioFileValidator;
 
     private final static String BOOK_IMAGE_PREFIX = "bookImages";
     private final static String BOOK_AUDIO_PREFIX = "bookAudios";
@@ -70,7 +72,7 @@ public class BookService {
 
     // 관심사 음성 기반 동화 생성
     public BookGenerateResponse generateBookFromVoice(Long memberId, MultipartFile audioFile) {
-        validateAudioFile(audioFile);
+        audioFileValidator.validate(audioFile);
 
         Member member = memberService.findById(memberId);
         BookReadingRecord latestRecord = getLatestRecord(memberId);
@@ -123,7 +125,7 @@ public class BookService {
     // 동화 낭독 음성 전송
     public void forwardReadingAudio(
             Long memberId, Long bookId, int sentenceNum, MultipartFile audioFile) {
-        validateAudioFile(audioFile);
+        audioFileValidator.validate(audioFile);
 
         Member member = memberService.findById(memberId);
         bookRepository.findById(bookId)
@@ -177,22 +179,6 @@ public class BookService {
                 .toList();
     }
 
-    private void validateAudioFile(MultipartFile audioFile) {
-        if (audioFile == null || audioFile.isEmpty()) {
-            throw new CustomException(ErrorCode.STT_EMPTY_RESULT);
-        }
-
-        String contentType = audioFile.getContentType();
-        if (!contentType.startsWith("audio/")) {
-            throw new CustomException(ErrorCode.INVALID_AUDIO_FILE);
-        }
-
-        // 음성 파일 30MB 제한
-        if (audioFile.getSize() > 30 * 1024 * 1024) {
-            throw new CustomException(ErrorCode.AUDIO_FILE_TOO_LARGE);
-        }
-    }
-
     private BookGenerateResponse buildAndSaveBook(Member member, FastApiStoryResponse fastApiResponse) {
         Book book = Book.of(member, fastApiResponse);
 
@@ -208,9 +194,7 @@ public class BookService {
         if (coverPrompt != null && !coverPrompt.isBlank()) {
             String coverFileName = UUID.randomUUID() + "_cover.png";
             CompletableFuture<Void> coverFuture = pageImageAsyncService.generateAndUpload(coverPrompt, bookSeed, coverFileName)
-                    .thenAccept(imageUrl -> {
-                        book.updateCoverImageUrl(imageUrl);
-                    });
+                    .thenAccept(book::updateCoverImageUrl);
 
             futures.add(coverFuture);
         }

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(404, "존재하는 사용자가 없습니다."),
     FORBIDDEN_CHILD_ONLY(403, "아동 회원만 사용 가능합니다."),
     INVALID_ROLE(403, "유효하지 않은 역할입니다."),
+    ACORN_COUNT_EXCEEDED(400, "도토리 개수를 초과했습니다."),
 
     // auth
     DUPLICATE_LOGIN_ID(409, "이미 존재하는 아이디입니다."),
@@ -30,6 +31,7 @@ public enum ErrorCode {
     BOOK_NOT_EXIST(401, "해당 회원이 보유하고 있는 책이 없습니다."),
     BOOK_NOT_FOUND(404, "해당 책이 존재하지 않습니다."),
     PAGE_NOT_FOUND(404, "해당 페이지가 존재하지 않습니다."),
+    BOOK_ACCESS_DENIED(403, "해당 책의 소유자가 아닙니다."),
 
     // Badge
     BADGE_NOT_FOUND(404, "보유한 뱃지가 없습니다."),
@@ -55,7 +57,12 @@ public enum ErrorCode {
     STT_TRANSCRIBE_FAILED(502, "STT 서버 요청에 실패했습니다."),
     STT_EMPTY_RESULT(422, "음성에서 텍스트를 인식하지 못했습니다."),
     INVALID_AUDIO_FILE(400, "유효하지 않은 음성 파일입니다."),
-    AUDIO_FILE_TOO_LARGE(400, "음성 파일의 크기가 너무 큽니다.");
+    AUDIO_FILE_TOO_LARGE(400, "음성 파일의 크기가 너무 큽니다."),
+
+    // quiz
+    QUIZ_NOT_FOUND(404, "해당 퀴즈가 존재하지 않습니다."),
+    QUIZ_GENERATE_FAILED(502, "퀴즈 생성 서버 요청에 실패했습니다."),
+    QUIZ_ANALYZE_FAILED(502, "퀴즈 분석 서버 요청에 실패했습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/ctrlS/totori/global/util/AudioFileValidator.java
+++ b/src/main/java/ctrlS/totori/global/util/AudioFileValidator.java
@@ -1,0 +1,26 @@
+package ctrlS.totori.global.util;
+
+import ctrlS.totori.global.exception.CustomException;
+import ctrlS.totori.global.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class AudioFileValidator {
+
+    public void validate(MultipartFile audioFile) {
+        if (audioFile == null || audioFile.isEmpty()) {
+            throw new CustomException(ErrorCode.STT_EMPTY_RESULT);
+        }
+
+        String contentType = audioFile.getContentType();
+        if (!contentType.startsWith("audio/")) {
+            throw new CustomException(ErrorCode.INVALID_AUDIO_FILE);
+        }
+
+        // 음성 파일 30MB 제한
+        if (audioFile.getSize() > 30 * 1024 * 1024) {
+            throw new CustomException(ErrorCode.AUDIO_FILE_TOO_LARGE);
+        }
+    }
+}

--- a/src/main/java/ctrlS/totori/global/util/AudioFileValidator.java
+++ b/src/main/java/ctrlS/totori/global/util/AudioFileValidator.java
@@ -18,8 +18,8 @@ public class AudioFileValidator {
             throw new CustomException(ErrorCode.INVALID_AUDIO_FILE);
         }
 
-        // 음성 파일 30MB 제한
-        if (audioFile.getSize() > 30 * 1024 * 1024) {
+        // 음성 파일 10MB 제한
+        if (audioFile.getSize() > 10 * 1024 * 1024) {
             throw new CustomException(ErrorCode.AUDIO_FILE_TOO_LARGE);
         }
     }

--- a/src/main/java/ctrlS/totori/member/entity/Member.java
+++ b/src/main/java/ctrlS/totori/member/entity/Member.java
@@ -1,6 +1,7 @@
 package ctrlS.totori.member.entity;
 
 import ctrlS.totori.global.entity.BaseTimeEntity;
+import ctrlS.totori.quiz.entity.QuizType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import lombok.*;
@@ -51,5 +52,9 @@ public class Member extends BaseTimeEntity {
         this.name = name;
         this.loginId = loginId;
         this.birthDate = birthdate;
+    }
+
+    public void earnAcorn() {
+        this.acorn++;
     }
 }

--- a/src/main/java/ctrlS/totori/member/entity/MemberLevel.java
+++ b/src/main/java/ctrlS/totori/member/entity/MemberLevel.java
@@ -1,5 +1,11 @@
 package ctrlS.totori.member.entity;
 
+import ctrlS.totori.quiz.entity.QuizType;
+
 public enum MemberLevel {
-    L1, L2, L3, L4, L5, L6
+    L1, L2, L3, L4, L5, L6;
+
+    public QuizType toQuizType() {
+        return this.ordinal() < 3 ? QuizType.PHONEME : QuizType.JOSA;
+    }
 }

--- a/src/main/java/ctrlS/totori/quiz/client/FastApiQuizClient.java
+++ b/src/main/java/ctrlS/totori/quiz/client/FastApiQuizClient.java
@@ -36,6 +36,23 @@ public class FastApiQuizClient {
                 .block();
     }
 
+    public FastApiAnalyzeQuizResponse analyzeQuiz(
+            MultipartFile audioFile,
+            String originalQuiz
+    ) {
+        MultipartBodyBuilder builder = buildQuizMultipartBody(audioFile, originalQuiz);
+
+        return fastApiSttWebClient.post()
+                .uri("/ai/quiz/analyze")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData((builder.build())))
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, clientResponse ->
+                        Mono.error(new CustomException(ErrorCode.QUIZ_ANALYZE_FAILED)))
+                .bodyToMono(FastApiAnalyzeQuizResponse.class)
+                .block();
+    }
+
     private MultipartBodyBuilder buildQuizMultipartBody(
             MultipartFile audioFile,
             String originalQuiz) {

--- a/src/main/java/ctrlS/totori/quiz/client/FastApiQuizClient.java
+++ b/src/main/java/ctrlS/totori/quiz/client/FastApiQuizClient.java
@@ -1,0 +1,61 @@
+package ctrlS.totori.quiz.client;
+
+import ctrlS.totori.global.exception.CustomException;
+import ctrlS.totori.global.exception.ErrorCode;
+import ctrlS.totori.quiz.dto.fastapi.FastApiAnalyzeQuizResponse;
+import ctrlS.totori.quiz.dto.fastapi.FastApiGenerateQuizRequest;
+import ctrlS.totori.quiz.dto.fastapi.FastApiGenerateQuizResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class FastApiQuizClient {
+
+    private final WebClient fastApiWebClient;
+    private final WebClient fastApiSttWebClient;
+
+    public FastApiGenerateQuizResponse generateQuiz(FastApiGenerateQuizRequest request) {
+        return fastApiWebClient.post()
+                .uri("/ai/quiz/generate")
+                .bodyValue(request)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, clientResponse ->
+                        Mono.error(new CustomException(ErrorCode.QUIZ_GENERATE_FAILED)))
+                .bodyToMono(FastApiGenerateQuizResponse.class)
+                .block();
+    }
+
+    private MultipartBodyBuilder buildQuizMultipartBody(
+            MultipartFile audioFile,
+            String originalQuiz) {
+        try {
+            String filename = audioFile.getOriginalFilename();
+            MediaType contentType = MediaType.parseMediaType(audioFile.getContentType());
+
+            ByteArrayResource resource = new ByteArrayResource(audioFile.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return filename;
+                }
+            };
+
+            MultipartBodyBuilder builder = new MultipartBodyBuilder();
+            builder.part("file", resource).contentType(contentType);
+            builder.part("original_quiz", originalQuiz);
+            return builder;
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.STT_FILE_READ_FAILED);
+        }
+    }
+}

--- a/src/main/java/ctrlS/totori/quiz/controller/QuizController.java
+++ b/src/main/java/ctrlS/totori/quiz/controller/QuizController.java
@@ -1,0 +1,46 @@
+package ctrlS.totori.quiz.controller;
+
+import ctrlS.totori.global.response.dto.BaseResponse;
+import ctrlS.totori.global.security.CustomUserPrincipal;
+import ctrlS.totori.quiz.dto.response.QuizAnalyzeResponse;
+import ctrlS.totori.quiz.dto.response.QuizResponse;
+import ctrlS.totori.quiz.service.QuizService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "퀴즈 API", description = "퀴즈 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/quiz")
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @Operation(summary = "퀴즈 생성", description = "레벨에 따라 읽기 오류 바탕으로 퀴즈를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "퀴즈 생성 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = QuizResponse.class))),
+            @ApiResponse(responseCode = "204", description = "퀴즈 없음", content = @Content)
+    })
+    @PostMapping("/generate")
+    public BaseResponse<?> generateQuizFromAudio(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @RequestParam("bookId") Long bookId) {
+        QuizResponse response = quizService.generateQuizFromAudio(principal.memberId(), bookId);
+
+        if (response == null) {
+            return BaseResponse.noContent();
+        }
+        return BaseResponse.ok(response);
+    }
+
+}

--- a/src/main/java/ctrlS/totori/quiz/controller/QuizController.java
+++ b/src/main/java/ctrlS/totori/quiz/controller/QuizController.java
@@ -43,4 +43,17 @@ public class QuizController {
         return BaseResponse.ok(response);
     }
 
+    @Operation(summary = "퀴즈 음성 전송", description = "퀴즈 음성을 수신하여 AI 서버로 전송합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "퀴즈 음성 전송 성공", content = @Content)
+    })
+    @PostMapping(value = "/{quizId}/check", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BaseResponse<QuizAnalyzeResponse> forwardQuizAudio(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable("quizId") Long quizId,
+            @RequestPart("audio") MultipartFile audioFile,
+            @RequestPart("original_quiz") String originalQuiz
+            ) {
+        return BaseResponse.ok(quizService.forwardQuizAudio(principal.memberId(), quizId, audioFile, originalQuiz));
+    }
 }

--- a/src/main/java/ctrlS/totori/quiz/controller/QuizController.java
+++ b/src/main/java/ctrlS/totori/quiz/controller/QuizController.java
@@ -56,4 +56,17 @@ public class QuizController {
             ) {
         return BaseResponse.ok(quizService.forwardQuizAudio(principal.memberId(), quizId, audioFile, originalQuiz));
     }
+
+    @Operation(summary = "퀴즈 조회", description = "퀴즈 한 세트를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "퀴즈 조회 성공", content = @Content)
+    })
+    @GetMapping(value = "/{quizId}")
+    public BaseResponse<QuizResponse> getQuiz(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable("quizId") Long quizId
+    ) {
+        return BaseResponse.ok(quizService.getQuiz(principal.memberId(), quizId));
+    }
+
 }

--- a/src/main/java/ctrlS/totori/quiz/dto/fastapi/FastApiAnalyzeQuizResponse.java
+++ b/src/main/java/ctrlS/totori/quiz/dto/fastapi/FastApiAnalyzeQuizResponse.java
@@ -1,0 +1,9 @@
+package ctrlS.totori.quiz.dto.fastapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FastApiAnalyzeQuizResponse(
+        @JsonProperty("is_correct")
+        boolean isCorrect
+) {
+}

--- a/src/main/java/ctrlS/totori/quiz/dto/fastapi/FastApiGenerateQuizRequest.java
+++ b/src/main/java/ctrlS/totori/quiz/dto/fastapi/FastApiGenerateQuizRequest.java
@@ -1,0 +1,14 @@
+package ctrlS.totori.quiz.dto.fastapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FastApiGenerateQuizRequest(
+        @JsonProperty("child_id")
+        Long childId,
+
+        @JsonProperty("book_id")
+        Long bookId,
+
+        String level
+) {
+}

--- a/src/main/java/ctrlS/totori/quiz/dto/fastapi/FastApiGenerateQuizResponse.java
+++ b/src/main/java/ctrlS/totori/quiz/dto/fastapi/FastApiGenerateQuizResponse.java
@@ -1,0 +1,11 @@
+package ctrlS.totori.quiz.dto.fastapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record FastApiGenerateQuizResponse(
+        @JsonProperty("quiz_items")
+        List<String> quizItems
+) {
+}

--- a/src/main/java/ctrlS/totori/quiz/dto/response/QuizAnalyzeResponse.java
+++ b/src/main/java/ctrlS/totori/quiz/dto/response/QuizAnalyzeResponse.java
@@ -1,0 +1,9 @@
+package ctrlS.totori.quiz.dto.response;
+
+public record QuizAnalyzeResponse(
+
+        boolean isCorrect,
+        boolean rewarded,
+        int currentAcorn
+) {
+}

--- a/src/main/java/ctrlS/totori/quiz/dto/response/QuizAnalyzeResponse.java
+++ b/src/main/java/ctrlS/totori/quiz/dto/response/QuizAnalyzeResponse.java
@@ -1,7 +1,6 @@
 package ctrlS.totori.quiz.dto.response;
 
 public record QuizAnalyzeResponse(
-
         boolean isCorrect,
         boolean rewarded,
         int currentAcorn

--- a/src/main/java/ctrlS/totori/quiz/dto/response/QuizResponse.java
+++ b/src/main/java/ctrlS/totori/quiz/dto/response/QuizResponse.java
@@ -1,0 +1,17 @@
+package ctrlS.totori.quiz.dto.response;
+
+import ctrlS.totori.quiz.entity.Quiz;
+
+import java.util.List;
+
+public record QuizResponse(
+        Long quizId,
+        List<String> quizItems
+) {
+    public static QuizResponse from(Quiz quiz) {
+        return new QuizResponse(
+                quiz.getId(),
+                quiz.getQuizItems()
+        );
+    }
+}

--- a/src/main/java/ctrlS/totori/quiz/entity/Quiz.java
+++ b/src/main/java/ctrlS/totori/quiz/entity/Quiz.java
@@ -1,0 +1,88 @@
+package ctrlS.totori.quiz.entity;
+
+import ctrlS.totori.book.entity.Book;
+import ctrlS.totori.global.entity.BaseTimeEntity;
+import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.entity.MemberLevel;
+import ctrlS.totori.quiz.dto.fastapi.FastApiGenerateQuizResponse;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "quizzes")
+public class Quiz extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    @Enumerated(EnumType.STRING)
+    private QuizType quizType; // PHONEME | JOSA
+
+    @Enumerated(EnumType.STRING)
+    private MemberLevel level; // L1-L6
+
+    @ElementCollection
+    @CollectionTable(name = "quiz_items",
+            joinColumns = @JoinColumn(name = "quiz_id"))
+    @Column(name = "item")
+    @OrderColumn(name = "item_order")
+    private List<String> quizItems;
+
+    @Column(nullable = false)
+    private boolean rewarded = false;
+
+    @Column(nullable = false)
+    private int correctCount = 0;
+
+    @Builder
+    public Quiz(Book book, Member member, MemberLevel level, QuizType quizType, List<String> quizItems) {
+        this.book = book;
+        this.member = member;
+        this.level = level;
+        this.quizType = quizType;
+        this.quizItems = quizItems != null ? new ArrayList<>(quizItems) : new ArrayList<>();
+    }
+
+    public static Quiz of(Book book, Member member, FastApiGenerateQuizResponse response) {
+        return Quiz.builder()
+                .book(book)
+                .member(member)
+                .level(member.getLevel())
+                .quizType(member.getLevel().toQuizType())
+                .quizItems(response.quizItems())
+                .build();
+    }
+
+    public void markAsRewarded() {
+        this.rewarded = true;
+    }
+
+    public boolean isRewardable() {
+        return !rewarded;
+    }
+
+    public void incrementCorrect() {
+        correctCount++;
+    }
+
+    public boolean isAllCorrect() {
+        return correctCount == quizItems.size();
+    }
+}

--- a/src/main/java/ctrlS/totori/quiz/entity/Quiz.java
+++ b/src/main/java/ctrlS/totori/quiz/entity/Quiz.java
@@ -66,13 +66,13 @@ public class Quiz extends BaseTimeEntity {
 
     public static Quiz of(Book book,
                           Member member,
-                          FastApiGenerateQuizResponse response) {
+                          List<String> quizItems) {
         return Quiz.builder()
                 .book(book)
                 .member(member)
                 .level(member.getLevel())
                 .quizType(member.getLevel().toQuizType())
-                .quizItems(response.quizItems())
+                .quizItems(quizItems)
                 .build();
     }
 

--- a/src/main/java/ctrlS/totori/quiz/entity/Quiz.java
+++ b/src/main/java/ctrlS/totori/quiz/entity/Quiz.java
@@ -52,7 +52,11 @@ public class Quiz extends BaseTimeEntity {
     private int correctCount = 0;
 
     @Builder
-    public Quiz(Book book, Member member, MemberLevel level, QuizType quizType, List<String> quizItems) {
+    public Quiz(Book book,
+                Member member,
+                MemberLevel level,
+                QuizType quizType,
+                List<String> quizItems) {
         this.book = book;
         this.member = member;
         this.level = level;
@@ -60,7 +64,9 @@ public class Quiz extends BaseTimeEntity {
         this.quizItems = quizItems != null ? new ArrayList<>(quizItems) : new ArrayList<>();
     }
 
-    public static Quiz of(Book book, Member member, FastApiGenerateQuizResponse response) {
+    public static Quiz of(Book book,
+                          Member member,
+                          FastApiGenerateQuizResponse response) {
         return Quiz.builder()
                 .book(book)
                 .member(member)

--- a/src/main/java/ctrlS/totori/quiz/entity/QuizType.java
+++ b/src/main/java/ctrlS/totori/quiz/entity/QuizType.java
@@ -1,0 +1,5 @@
+package ctrlS.totori.quiz.entity;
+
+public enum QuizType {
+    PHONEME, JOSA
+}

--- a/src/main/java/ctrlS/totori/quiz/repository/QuizRepository.java
+++ b/src/main/java/ctrlS/totori/quiz/repository/QuizRepository.java
@@ -1,0 +1,7 @@
+package ctrlS.totori.quiz.repository;
+
+import ctrlS.totori.quiz.entity.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+}

--- a/src/main/java/ctrlS/totori/quiz/service/QuizService.java
+++ b/src/main/java/ctrlS/totori/quiz/service/QuizService.java
@@ -63,4 +63,46 @@ public class QuizService {
 
         return new QuizResponse(savedQuiz.getId(), savedQuiz.getQuizItems());
     }
+
+    // 퀴즈 음성 전송
+    public QuizAnalyzeResponse forwardQuizAudio(
+            Long memberId, Long quizId, MultipartFile audioFile, String originalQuiz) {
+        audioFileValidator.validate(audioFile);
+
+        Member member = memberService.findById(memberId);
+
+        MemberStat stat = memberStatRepository.findByMember(member)
+                .orElseThrow(() -> new CustomException(ErrorCode.STAT_NOT_FOUND));
+
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_NOT_FOUND));
+
+        if (!Objects.equals(quiz.getBook().getMember().getId(), member.getId())) {
+            throw new CustomException(ErrorCode.BOOK_ACCESS_DENIED);
+        }
+
+        FastApiAnalyzeQuizResponse fastApiResponse = fastApiQuizClient.analyzeQuiz(
+                audioFile,
+                originalQuiz
+        );
+
+        boolean isCorrect = fastApiResponse.isCorrect();
+        boolean rewarded = false;
+
+        if (isCorrect) {
+            quiz.incrementCorrect();
+        }
+
+        if (quiz.isAllCorrect() && quiz.isRewardable()) {
+            quiz.markAsRewarded();
+            quiz.getBook().addAcorn();
+            member.earnAcorn();
+            stat.addAcquiredAcorn(1);
+            badgeService.checkAndGrantBadge(memberId, BadgeCategory.ACORN);
+            rewarded = true;
+        }
+
+        return new QuizAnalyzeResponse(isCorrect, rewarded, member.getAcorn());
+    }
+    }
 }

--- a/src/main/java/ctrlS/totori/quiz/service/QuizService.java
+++ b/src/main/java/ctrlS/totori/quiz/service/QuizService.java
@@ -104,5 +104,19 @@ public class QuizService {
 
         return new QuizAnalyzeResponse(isCorrect, rewarded, member.getAcorn());
     }
+
+    // 퀴즈 조회
+    @Transactional(readOnly = true)
+    public QuizResponse getQuiz(Long memberId, Long quizId) {
+        Member member = memberService.findById(memberId);
+
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_NOT_FOUND));
+
+        if (!Objects.equals(quiz.getBook().getMember().getId(), member.getId())) {
+            throw new CustomException(ErrorCode.BOOK_ACCESS_DENIED);
+        }
+
+        return QuizResponse.from(quiz);
     }
 }

--- a/src/main/java/ctrlS/totori/quiz/service/QuizService.java
+++ b/src/main/java/ctrlS/totori/quiz/service/QuizService.java
@@ -1,0 +1,66 @@
+package ctrlS.totori.quiz.service;
+
+import ctrlS.totori.badge.entity.BadgeCategory;
+import ctrlS.totori.badge.service.BadgeService;
+import ctrlS.totori.book.entity.Book;
+import ctrlS.totori.book.repository.BookRepository;
+import ctrlS.totori.global.exception.CustomException;
+import ctrlS.totori.global.exception.ErrorCode;
+import ctrlS.totori.global.util.AudioFileValidator;
+import ctrlS.totori.member.entity.Member;
+import ctrlS.totori.member.entity.MemberStat;
+import ctrlS.totori.member.repository.MemberStatRepository;
+import ctrlS.totori.member.service.MemberService;
+import ctrlS.totori.quiz.client.FastApiQuizClient;
+import ctrlS.totori.quiz.dto.fastapi.FastApiAnalyzeQuizResponse;
+import ctrlS.totori.quiz.dto.fastapi.FastApiGenerateQuizRequest;
+import ctrlS.totori.quiz.dto.fastapi.FastApiGenerateQuizResponse;
+import ctrlS.totori.quiz.dto.response.QuizAnalyzeResponse;
+import ctrlS.totori.quiz.dto.response.QuizResponse;
+import ctrlS.totori.quiz.entity.Quiz;
+import ctrlS.totori.quiz.repository.QuizRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizService {
+
+    private final MemberService memberService;
+    private final MemberStatRepository memberStatRepository;
+    private final BookRepository bookRepository;
+    private final QuizRepository quizRepository;
+    private final FastApiQuizClient fastApiQuizClient;
+    private final AudioFileValidator audioFileValidator;
+    private final BadgeService badgeService;
+
+    // 퀴즈 생성
+    public QuizResponse generateQuizFromAudio(Long memberId, Long bookId) {
+        Member member = memberService.findById(memberId);
+
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
+
+        if (!Objects.equals(book.getMember().getId(), member.getId())) {
+            throw new CustomException(ErrorCode.BOOK_ACCESS_DENIED);
+        }
+
+        FastApiGenerateQuizRequest request = new FastApiGenerateQuizRequest(member.getId(), book.getId(), member.getLevel().name());
+        FastApiGenerateQuizResponse fastApiResponse = fastApiQuizClient.generateQuiz(request);
+
+        if (fastApiResponse == null) {
+            return null;
+        }
+
+        Quiz quiz = Quiz.of(book, member, fastApiResponse);
+
+        Quiz savedQuiz = quizRepository.save(quiz);
+
+        return new QuizResponse(savedQuiz.getId(), savedQuiz.getQuizItems());
+    }
+}

--- a/src/main/java/ctrlS/totori/quiz/service/QuizService.java
+++ b/src/main/java/ctrlS/totori/quiz/service/QuizService.java
@@ -57,7 +57,7 @@ public class QuizService {
             return null;
         }
 
-        Quiz quiz = Quiz.of(book, member, fastApiResponse);
+        Quiz quiz = Quiz.of(book, member, fastApiResponse.quizItems());
 
         Quiz savedQuiz = quizRepository.save(quiz);
 


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 퀴즈 생성, 조회, 낭독 음성 전송 api 구현했습니다.
- 퀴즈 정답인 경우 도토리 획득하는 로직 구현했습니다.

## 📍 변경 사항
Create: AudioFileValidator, Quiz, QuizType, FastApiGenerateQuizRequest, FastApiGenerateQuizResponse, FastApiAnalyzeQuizResponse, FastApiQuizClient, QuizResponse, QuizAnalyzeResponse, QuizRepository, QuizController, QuizService
Update: ErrorCode, Book, BookPage, BookService, Member, MemberLevel
  
## 🚧 구현 중 겪은 이슈 및 해결 방법
- 문제: Redis에 음소 오류 데이터가 없어 퀴즈 생성 시 FastAPI에서 404 반환하는 문제가 있었습니다.
해결: 낭독 오류 없는 경우 예외가 아닌 정상 케이스로 처리하여 204 No Content 반환하도록 변경했습니다.
- 문제: books 테이블의 cover_image_prompt 컬럼이 VARCHAR(255)로 설정되어 GPT 생성 프롬프트 저장 시 Data truncation 에러가 발생했습니다.
해결: `@Column(columnDefinition = "TEXT")`로 변경했습니다.

## 🔍 참고 사항
- `{{baseUrl}}/api/quiz/generate?bookId={bookId}`
Query Params에 bookId를 넣고 요청하면 FastApi Redis에 저장되어 있는 음성 오류 패턴을 바탕으로 음운/조사 퀴즈가 생성됩니다.
<img width="651" height="703" alt="스크린샷 2026-05-12 오후 12 02 30" src="https://github.com/user-attachments/assets/c7f083f3-7778-468d-be3e-01f2a53f06b5" />

만약 음성 오류가 없는 경우 `204 No Content`가 됩니다.
<img width="658" height="498" alt="스크린샷 2026-05-12 오후 12 15 03" src="https://github.com/user-attachments/assets/c0eb866a-fd94-4236-9d11-2b4375bdf58c" />

- `{{baseUrl}}/api/quiz/{quizId}`
Path variable에 quizId를 넣고 요청하면 퀴즈 한 세트를 조회합니다.
<img width="658" height="700" alt="스크린샷 2026-05-12 오후 12 16 29" src="https://github.com/user-attachments/assets/16972280-e2db-44c7-a74d-924e7f942fcd" />

- {{baseUrl}}/api/quiz/{quizId}/check
Path variable에 quizId를 넣고, Body에 audio(퀴즈 음성.m4a)와 original_quiz(퀴즈 원본 텍스트)를 넣고 요청하면 isCorrect(퀴즈 정답 여부)와 rewarded(도토리 획득 여부)와 currentAcorn(현재 도토리 개수)를 반환합니다.
<img width="659" height="634" alt="스크린샷 2026-05-12 오후 12 18 59" src="https://github.com/user-attachments/assets/12949255-76ac-4023-b072-19ef278810a9" />

퀴즈 한 세트에 퀴즈가 4개 있으므로 퀴즈 정답 4번 나오는 경우 rewarded(도토리 획득 여부)가 true로 나오고 currentAcorn(현재 도토리 개수)가 하나 증가합니다.
<img width="659" height="638" alt="스크린샷 2026-05-12 오후 12 19 17" src="https://github.com/user-attachments/assets/70b79362-1173-4162-800b-561252762d47" />


## ✨ 관련 이슈
- closes #39 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [x] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
