### PR TITLE
[Hotfix] 1주일치 책 리스트 조회 시 아동기준이 아닌 연결된 학부모 기준으로 변경

### DIFF
--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -133,9 +133,10 @@ public class BookService {
 
     @Transactional(readOnly = true)
     public BookWeeklyListResponse getWeeklyReport(Long memberId) {
+        Member child = memberService.findChildByParentId(memberId);
         LocalDateTime startDateTime = LocalDateTime.now().minusDays(6).with(LocalTime.MIN);
 
-        List<Book> weeklyBooks = bookRepository.findWeeklyBooks(memberId, startDateTime);
+        List<Book> weeklyBooks = bookRepository.findWeeklyBooks(child.getId(), startDateTime);
 
         Map<LocalDate, List<BookReportSummary>> groupedData = weeklyBooks.stream()
                 .collect(Collectors.groupingBy(


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 1주일치 책 리스트 조회 시 아동기준이 아닌 연결된 학부모 기준으로 변경


## ✨ 관련 이슈
- closes #89

## 🔧 변경 유형
* [x] Bug Fix (fix)
* [ ] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [ ] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
