### PR TITLE
[Feat] 동화 낭독 완료 FastAPI 연결

### DIFF
--- a/src/main/java/ctrlS/totori/book/client/FastApiStoryClient.java
+++ b/src/main/java/ctrlS/totori/book/client/FastApiStoryClient.java
@@ -1,6 +1,7 @@
 package ctrlS.totori.book.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import ctrlS.totori.book.dto.fastApi.FastApiCompleteStoryResponse;
 import ctrlS.totori.book.dto.fastApi.FastApiGenerateStoryRequest;
 import ctrlS.totori.book.dto.fastApi.FastApiStoryResponse;
 import ctrlS.totori.global.exception.CustomException;
@@ -22,11 +23,11 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class FastApiStoryClient {
-
     private final WebClient fastApiWebClient;
     private final WebClient fastApiSttWebClient;
     private final ObjectMapper objectMapper;
 
+    // 동화 생성
     public FastApiStoryResponse generateStory(FastApiGenerateStoryRequest request) {
         return fastApiWebClient.post()
                 .uri("/ai/story/generate")
@@ -38,6 +39,7 @@ public class FastApiStoryClient {
                 .block();
     }
 
+    // 관심사 음성 기반 동화 생성
     public FastApiStoryResponse generateStoryFromAudio(
             MultipartFile audioFile,
             String level,
@@ -56,6 +58,7 @@ public class FastApiStoryClient {
                 .block();
     }
 
+    // 동화 낭독
     public void analyzeReading(
             MultipartFile audioFile,
             String originalText,
@@ -80,30 +83,21 @@ public class FastApiStoryClient {
             String level,
             Float recentWcpm,
             List<String> weakPhonemes) {
-        try {
-            String filename = audioFile.getOriginalFilename();
-            MediaType contentType = MediaType.parseMediaType(audioFile.getContentType());
+        MultipartBodyBuilder builder = createMultipartBuilderWithAudio(audioFile);
 
-            ByteArrayResource resource = new ByteArrayResource(audioFile.getBytes()) {
-                @Override
-                public String getFilename() {
-                    return filename;
-                }
-            };
-
-            MultipartBodyBuilder builder = new MultipartBodyBuilder();
-            builder.part("file", resource).contentType(contentType);
-            builder.part("level", level);
-            if (recentWcpm != null) {
-                builder.part("recent_wcpm", recentWcpm.toString());
-            }
-            if (weakPhonemes != null && !weakPhonemes.isEmpty()) {
-                builder.part("weak_phonemes", objectMapper.writeValueAsString(weakPhonemes));
-            }
-            return builder;
-        } catch (IOException e) {
-            throw new CustomException(ErrorCode.STT_FILE_READ_FAILED);
+        builder.part("level", level);
+        if (recentWcpm != null) {
+            builder.part("recent_wcpm", recentWcpm.toString());
         }
+        if (weakPhonemes != null && !weakPhonemes.isEmpty()) {
+            try {
+                builder.part("weak_phonemes", objectMapper.writeValueAsString(weakPhonemes));
+            } catch (IOException e) {
+                throw new CustomException(ErrorCode.STT_FILE_READ_FAILED);
+            }
+        }
+
+        return builder;
     }
 
     private MultipartBodyBuilder buildReadingMultipartBody(
@@ -112,8 +106,21 @@ public class FastApiStoryClient {
             Long childId,
             Long bookId,
             String level) {
+        MultipartBodyBuilder builder = createMultipartBuilderWithAudio(audioFile);
+
+        builder.part("original_text", originalText);
+        builder.part("child_id", childId.toString());
+        builder.part("book_id", bookId.toString());
+        builder.part("level", level);
+
+        return builder;
+    }
+
+    private MultipartBodyBuilder createMultipartBuilderWithAudio(MultipartFile audioFile) {
         try {
             String filename = audioFile.getOriginalFilename();
+
+            audioFile.getContentType();
             MediaType contentType = MediaType.parseMediaType(audioFile.getContentType());
 
             ByteArrayResource resource = new ByteArrayResource(audioFile.getBytes()) {
@@ -125,10 +132,7 @@ public class FastApiStoryClient {
 
             MultipartBodyBuilder builder = new MultipartBodyBuilder();
             builder.part("file", resource).contentType(contentType);
-            builder.part("original_text", originalText);
-            builder.part("child_id", childId.toString());
-            builder.part("book_id", bookId.toString());
-            builder.part("level", level);
+
             return builder;
         } catch (IOException e) {
             throw new CustomException(ErrorCode.STT_FILE_READ_FAILED);

--- a/src/main/java/ctrlS/totori/book/client/FastApiStoryClient.java
+++ b/src/main/java/ctrlS/totori/book/client/FastApiStoryClient.java
@@ -78,6 +78,17 @@ public class FastApiStoryClient {
                 .block();
     }
 
+    // 동화 낭독 완료
+    public FastApiCompleteStoryResponse completeReading(Long childId, Long bookId) {
+        return fastApiWebClient.post()
+                .uri("/ai/reading/complete/{child_id}/{book_id}",childId, bookId)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, clientResponse ->
+                        Mono.error(new CustomException(ErrorCode.READING_COMPLETE_FAILED)))
+                .bodyToMono(FastApiCompleteStoryResponse.class)
+                .block();
+    }
+
     private MultipartBodyBuilder buildMultipartBody(
             MultipartFile audioFile,
             String level,

--- a/src/main/java/ctrlS/totori/book/dto/fastApi/FastApiCompleteStoryResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/fastApi/FastApiCompleteStoryResponse.java
@@ -1,0 +1,17 @@
+package ctrlS.totori.book.dto.fastApi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import ctrlS.totori.book.dto.fastApi.reading.FastApiErrorItem;
+
+import java.util.List;
+
+public record FastApiCompleteStoryResponse(
+        @JsonProperty("child_id")
+        Long childId,
+        @JsonProperty("book_id")
+        Long bookId,
+        List<FastApiErrorItem> errors,
+        @JsonProperty("avg_wcpm")
+        Float avgWcpm
+) {
+}

--- a/src/main/java/ctrlS/totori/book/dto/fastApi/FastApiGenerateStoryRequest.java
+++ b/src/main/java/ctrlS/totori/book/dto/fastApi/FastApiGenerateStoryRequest.java
@@ -7,12 +7,9 @@ import java.util.List;
 public record FastApiGenerateStoryRequest(
         @JsonProperty("stt_text")
         String sttText,
-
         String level,
-
         @JsonProperty("recent_wcpm")
         Float recentWcpm,
-
         @JsonProperty("weak_phonemes")
         List<String> weakPhonemes
 ) { }

--- a/src/main/java/ctrlS/totori/book/dto/fastApi/FastApiPageResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/fastApi/FastApiPageResponse.java
@@ -8,9 +8,7 @@ import java.util.List;
 public record FastApiPageResponse(
         @JsonProperty("page_order")
         int pageOrder,
-
         @JsonProperty("image_prompt")
         String imagePrompt,
-
         List<SentenceData> sentences
 ) { }

--- a/src/main/java/ctrlS/totori/book/dto/fastApi/FastApiStoryResponse.java
+++ b/src/main/java/ctrlS/totori/book/dto/fastApi/FastApiStoryResponse.java
@@ -6,10 +6,8 @@ import java.util.List;
 
 public record FastApiStoryResponse(
         String title,
-
         @JsonProperty("cover_image_prompt")
         String coverImagePrompt,
-
         List<FastApiPageResponse> pages
 ) {
 }

--- a/src/main/java/ctrlS/totori/book/dto/fastApi/reading/FastApiErrorItem.java
+++ b/src/main/java/ctrlS/totori/book/dto/fastApi/reading/FastApiErrorItem.java
@@ -1,0 +1,12 @@
+package ctrlS.totori.book.dto.fastApi.reading;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = FastApiPhonemeError.class, name = "phoneme"),
+        @JsonSubTypes.Type(value = FastApiJosaError.class, name = "josa")
+})
+public abstract class FastApiErrorItem {
+}

--- a/src/main/java/ctrlS/totori/book/dto/fastApi/reading/FastApiJosaError.java
+++ b/src/main/java/ctrlS/totori/book/dto/fastApi/reading/FastApiJosaError.java
@@ -1,0 +1,17 @@
+package ctrlS.totori.book.dto.fastApi.reading;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import ctrlS.totori.book.dto.fastApi.reading.FastApiErrorItem;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FastApiJosaError extends FastApiErrorItem {
+    private String kind;
+    private String stem;
+    @JsonProperty("target_josa")
+    private String targetJosa;
+    @JsonProperty("stt_josa")
+    private String sttJosa;
+}

--- a/src/main/java/ctrlS/totori/book/dto/fastApi/reading/FastApiPhonemeError.java
+++ b/src/main/java/ctrlS/totori/book/dto/fastApi/reading/FastApiPhonemeError.java
@@ -1,0 +1,12 @@
+package ctrlS.totori.book.dto.fastApi.reading;
+
+import ctrlS.totori.book.dto.fastApi.reading.FastApiErrorItem;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FastApiPhonemeError extends FastApiErrorItem {
+    private String pattern;
+    private String word;
+}

--- a/src/main/java/ctrlS/totori/book/entity/Book.java
+++ b/src/main/java/ctrlS/totori/book/entity/Book.java
@@ -63,7 +63,9 @@ public class Book extends BaseTimeEntity {
                 .title(response.title())
                 .coverImageUrl(null)
                 .coverImagePrompt(response.coverImagePrompt())
-                .totalPages(response.pages().size())
+                .totalPages(response.pages().stream()
+                        .mapToInt(page -> page.sentences().size())
+                        .sum())
                 .build();
     }
 

--- a/src/main/java/ctrlS/totori/book/entity/BookReadingRecord.java
+++ b/src/main/java/ctrlS/totori/book/entity/BookReadingRecord.java
@@ -59,6 +59,18 @@ public class BookReadingRecord extends BaseTimeEntity {
         this.mistakes = mistakes != null ? mistakes : new HashMap<>();
     }
 
+    public static BookReadingRecord of(Book book) {
+        return BookReadingRecord.builder()
+                .book(book)
+                .readPages(0)
+                .isCompleted(false)
+                .wcpm(0f)
+                .totalWordCount(0)
+                .wrongWordCount(0)
+                .wrongWords(null)
+                .build();
+    }
+
     public void markAsCompleted() {
         this.isCompleted = true;
         this.readPages = this.book.getTotalPages();

--- a/src/main/java/ctrlS/totori/book/entity/BookReadingRecord.java
+++ b/src/main/java/ctrlS/totori/book/entity/BookReadingRecord.java
@@ -63,4 +63,9 @@ public class BookReadingRecord extends BaseTimeEntity {
         this.isCompleted = true;
         this.readPages = this.book.getTotalPages();
     }
+
+    public void updateReadingStat(float wcpm, Map<String, Integer> mistakes) {
+        this.wcpm = wcpm;
+        this.mistakes = mistakes;
+    }
 }

--- a/src/main/java/ctrlS/totori/book/entity/BookReadingRecord.java
+++ b/src/main/java/ctrlS/totori/book/entity/BookReadingRecord.java
@@ -68,4 +68,8 @@ public class BookReadingRecord extends BaseTimeEntity {
         this.wcpm = wcpm;
         this.mistakes = mistakes;
     }
+
+    public void updateReadPages(int readPages) {
+        this.readPages = Math.max(this.readPages, readPages);
+    }
 }

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -184,6 +184,11 @@ public class BookService {
                 bookId,
                 member.getLevel().toString()
         );
+
+        BookReadingRecord record = bookReadingRecordRepository.findLatestByBookId(bookId)
+                .orElseThrow(() -> new CustomException(ErrorCode.READING_RECORD_NOT_EXIST));
+
+        record.updateReadPages(sentenceNum + 1);
     }
 
     public BookDetailResponse getBookDetail(Long memberId, Long bookId) {

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -5,8 +5,11 @@ import ctrlS.totori.badge.dto.MemberBadgeResponseDto;
 import ctrlS.totori.badge.entity.BadgeCategory;
 import ctrlS.totori.badge.service.BadgeService;
 import ctrlS.totori.book.client.FastApiStoryClient;
+import ctrlS.totori.book.dto.fastApi.FastApiCompleteStoryResponse;
 import ctrlS.totori.book.dto.fastApi.FastApiGenerateStoryRequest;
 import ctrlS.totori.book.dto.fastApi.FastApiStoryResponse;
+import ctrlS.totori.book.dto.fastApi.reading.FastApiJosaError;
+import ctrlS.totori.book.dto.fastApi.reading.FastApiPhonemeError;
 import ctrlS.totori.book.dto.request.BookCompleteRequest;
 import ctrlS.totori.book.dto.request.BookGenerateRequest;
 import ctrlS.totori.book.dto.response.*;
@@ -183,12 +186,13 @@ public class BookService {
         );
     }
 
-    @Transactional
     public BookDetailResponse getBookDetail(Long memberId, Long bookId) {
+        Member member = memberService.findById(memberId);
+
         Book book = bookRepository.findByIdWithPages(bookId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
 
-        if (!book.getMember().getId().equals(memberId)) {
+        if (!book.getMember().getId().equals(member.getId())) {
             throw new CustomException(ErrorCode.BOOK_ACCESS_DENIED);
         }
 
@@ -209,13 +213,79 @@ public class BookService {
         return BookDetailResponse.of(cover, pageResponses);
     }
 
+    public BookCompleteResponse completeBook(Long memberId, Long bookId, BookCompleteRequest request) {
+        Member member = memberService.findById(memberId);
+
+        Book book = bookRepository.findByIdAndMemberId(bookId, member.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_ACCESS_DENIED));
+
+        BookReadingRecord latestRecord = bookReadingRecordRepository.findLatestByBookId(bookId)
+                .orElseThrow(() -> new CustomException(ErrorCode.READING_RECORD_NOT_EXIST));
+
+        if (latestRecord.isCompleted()) {
+            return BookCompleteResponse.of(book, 0, List.of());
+        }
+
+        latestRecord.markAsCompleted();
+        FastApiCompleteStoryResponse fastApiResponse = fastApiStoryClient.completeReading(member.getId(), bookId);
+
+        if (fastApiResponse != null) {
+            float wcpm = fastApiResponse.avgWcpm() != null ? fastApiResponse.avgWcpm() : 0f;
+
+            // phoneme 수집
+            Map<String, Integer> phonemeMistakes = fastApiResponse.errors().stream()
+                    .filter(e -> e instanceof FastApiPhonemeError)
+                    .map(e -> (FastApiPhonemeError) e)
+                    .collect(Collectors.groupingBy(
+                            e -> "phoneme:" + e.getPattern(),
+                            Collectors.summingInt(e -> 1)
+                    ));
+
+            // josa 수집
+            Map<String, Integer> josaMistakes = fastApiResponse.errors().stream()
+                    .filter(e -> e instanceof FastApiJosaError)
+                    .map(e -> (FastApiJosaError) e)
+                            .collect(Collectors.groupingBy(
+                                    e -> "josa:" + e.getKind(),
+                                    Collectors.summingInt(e -> 1)
+                            ));
+
+            Map<String, Integer> mistakes = new HashMap<>();
+            mistakes.putAll(phonemeMistakes);
+            mistakes.putAll(josaMistakes);
+
+            latestRecord.updateReadingStat(wcpm, mistakes);
+        }
+
+        int acornCount = request.acornCount();
+        book.addReceivedAcorn(acornCount);
+
+        MemberStat memberStat = memberStatRepository.findByMember(member)
+                .orElseThrow(() -> new CustomException(ErrorCode.STAT_NOT_FOUND));
+
+        memberStat.addReadBook();
+
+        if (acornCount > 0) {
+            memberStat.addAcquiredAcorn(acornCount);
+        }
+
+        List<BadgeResponseDto> newlyAcquiredBadges = new ArrayList<>();
+        newlyAcquiredBadges.addAll(badgeService.checkAndGrantBadge(memberId, BadgeCategory.BOOK_READ));
+        if (acornCount > 0) {
+            newlyAcquiredBadges.addAll(badgeService.checkAndGrantBadge(memberId, BadgeCategory.ACORN));
+        }
+
+        return BookCompleteResponse.of(book, acornCount, newlyAcquiredBadges);
+    }
+
     protected BookReadingRecord getLatestRecord(Long memberId) {
         return bookReadingRecordRepository
                 .findTopByBook_Member_IdOrderByUpdatedAtDesc(memberId)
                 .orElse(null);
     }
 
-    private FastApiGenerateStoryRequest createFastApiRequest(BookGenerateRequest request, Member member, BookReadingRecord latestRecord) {
+    private FastApiGenerateStoryRequest createFastApiRequest(
+            BookGenerateRequest request, Member member, BookReadingRecord latestRecord) {
         float recentWcpm = latestRecord != null ? latestRecord.getWcpm() : 0f;
         List<String> weakPhonemes = extractWeakPhonemes(latestRecord);
 
@@ -228,15 +298,16 @@ public class BookService {
     }
 
     private List<String> extractWeakPhonemes(BookReadingRecord latestRecord) {
-        if (latestRecord == null || latestRecord.getMistakes() == null || latestRecord.getMistakes().isEmpty()) {
+        if (latestRecord == null || latestRecord.getMistakes() == null) {
             return List.of();
         }
 
         return latestRecord.getMistakes().entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith("phoneme:"))
                 .filter(entry -> entry.getValue() != null && entry.getValue() > 0)
-                .sorted(Map.Entry.<String, Integer>comparingByValue(Comparator.reverseOrder()))
+                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
                 .limit(3)
-                .map(Map.Entry::getKey)
+                .map(entry -> entry.getKey().replace("phoneme", ""))
                 .toList();
     }
 
@@ -305,42 +376,6 @@ public class BookService {
                 .toList();
 
         return BookGenerateResponse.of(savedBook, presignedCoverUrl, pageResponses);
-    }
-
-    @Transactional
-    public BookCompleteResponse completeBook(Long memberId, Long bookId, BookCompleteRequest request) {
-        Book book = bookRepository.findByIdAndMemberId(bookId, memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_ACCESS_DENIED));
-
-        BookReadingRecord latestRecord = bookReadingRecordRepository.findLatestByBookId(bookId)
-                .orElseThrow(() -> new CustomException(ErrorCode.READING_RECORD_NOT_EXIST));
-
-        if (latestRecord.isCompleted()) {
-            return BookCompleteResponse.of(book, 0, List.of());
-        }
-
-        latestRecord.markAsCompleted();
-
-        int acornCount = request.acornCount();
-        book.addReceivedAcorn(acornCount);
-
-        Member member = memberService.findById(memberId);
-        MemberStat memberStat = memberStatRepository.findByMember(member)
-                .orElseThrow(() -> new CustomException(ErrorCode.STAT_NOT_FOUND));
-
-        memberStat.addReadBook();
-
-        if (acornCount > 0) {
-            memberStat.addAcquiredAcorn(acornCount);
-        }
-
-        List<BadgeResponseDto> newlyAcquiredBadges = new ArrayList<>();
-        newlyAcquiredBadges.addAll(badgeService.checkAndGrantBadge(memberId, BadgeCategory.BOOK_READ));
-        if (acornCount > 0) {
-            newlyAcquiredBadges.addAll(badgeService.checkAndGrantBadge(memberId, BadgeCategory.ACORN));
-        }
-
-        return BookCompleteResponse.of(book, acornCount, newlyAcquiredBadges);
     }
 
     private BookPageDetailResponse toPageDetailResponse(BookPage page) {

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -349,6 +349,18 @@ public class BookService {
 
         Book savedBook = bookRepository.save(book);
 
+        BookReadingRecord record = BookReadingRecord.builder()
+                .book(savedBook)
+                .readPages(0)
+                .isCompleted(false)
+                .wcpm(0f)
+                .totalWordCount(0)
+                .wrongWordCount(0)
+                .wrongWords(null)
+                .build();
+
+        bookReadingRecordRepository.save(record);
+
         MemberStat memberStat = memberStatRepository.findByMember(member)
                 .orElseThrow(() -> new CustomException(ErrorCode.STAT_NOT_FOUND));
         memberStat.addCreatedBook();

--- a/src/main/java/ctrlS/totori/book/service/BookService.java
+++ b/src/main/java/ctrlS/totori/book/service/BookService.java
@@ -354,15 +354,7 @@ public class BookService {
 
         Book savedBook = bookRepository.save(book);
 
-        BookReadingRecord record = BookReadingRecord.builder()
-                .book(savedBook)
-                .readPages(0)
-                .isCompleted(false)
-                .wcpm(0f)
-                .totalWordCount(0)
-                .wrongWordCount(0)
-                .wrongWords(null)
-                .build();
+        BookReadingRecord record = BookReadingRecord.of(savedBook);
 
         bookReadingRecordRepository.save(record);
 

--- a/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
+++ b/src/main/java/ctrlS/totori/global/exception/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
     BOOK_ACCESS_DENIED(403, "해당 책의 소유자가 아닙니다."),
     READING_RECORD_NOT_EXIST(404, "낭독 정보가 존재하지 않습니다."),
     INVALID_SENTENCE_NUM(400, "문장 번호는 0 이상이어야 합니다."),
+    STORY_GENERATE_FAILED(502, "동화 생성 서버 요청에 실패했습니다."),
+    READING_COMPLETE_FAILED(502, "동화 낭독 완료 처리 서버 요청에 실패했습니다."),
 
     // Badge
     BADGE_NOT_FOUND(404, "보유한 뱃지가 없습니다."),


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 동화 낭독 완료 FastAPI 연결했습니다.

## 📍 변경 사항
Create: FastApiCompleteStoryResponse, FastApiErrorItem, FastApiJosaError, FastApiPhonomeError, 
Update: FastApiStoryClient, FastApiGenerateStoryRequest, FastApiPageResponse, FastApiStoryResponse, ErrorCode, BookReadingRecord, BookService

  
## 🚧 구현 중 겪은 이슈 및 해결 방법
- 문제: 동화 낭독 진행 후 낭독 완료 요청 시 낭독 정보가 존재하지 않는다는 오류가 발생했습니다.
해결: 동화 생성 시 BookReadingRecord도 같이 생성되도록 하였습니다. 또한 동화 낭독 시 읽은 페이지를 업데이트하도록 수정했습니다. 테스트 시 기존에 생성된 동화는 BookReadingRecord를 붙이거나 아예 새로운 동화를 생성한 다음 테스트하는 편이 좋을 것 같습니다.

## 🔍 참고 사항
<img width="656" height="651" alt="스크린샷 2026-05-16 오후 9 21 45" src="https://github.com/user-attachments/assets/b369dfd4-2ba1-40ce-8142-0a4f452a7f3f" />

FastAPI 응답의 errors는 `phoneme`, `josa` 두 타입으로 나눠서 받지만 Spring에서는 두 타입 모두 `mistakes`에 저장합니다. 이때, key에 타입 prefix(phonome, josa)를 붙여 구분합니다.
리포트에서는 음운 오류와 조사 오류를 따로 구분하지 않기에 리포트 관련 코드는 수정할 필요 없을 것 같습니다.

## ✨ 관련 이슈
- closes #97 

## 🔧 변경 유형
* [ ] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [x] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
