### PR TITLE
[Hotfix] 보호자 로그인 시 아동 연결 여부 확인 

### DIFF
--- a/src/main/java/ctrlS/totori/auth/controller/AuthController.java
+++ b/src/main/java/ctrlS/totori/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package ctrlS.totori.auth.controller;
 
 import ctrlS.totori.auth.dto.LoginRequest;
+import ctrlS.totori.auth.dto.LoginResponse;
 import ctrlS.totori.auth.dto.SignUpRequest;
 import ctrlS.totori.auth.dto.TokenResponse;
 import ctrlS.totori.auth.service.AuthService;
@@ -29,7 +30,7 @@ public class AuthController {
 
     @Operation(summary = "자체 회원가입", description = "역할, 아이디, 비밀번호, 이름을 입력받아 회원가입을 진행합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청값", content = @Content),
             @ApiResponse(responseCode = "409", description = "이미 존재하는 아이디", content = @Content)})
     @PostMapping("/signup")
@@ -47,9 +48,9 @@ public class AuthController {
             @ApiResponse(responseCode = "404", description = "가입되지 않은 아이디", content = @Content)
     })
     @PostMapping("/login")
-    public BaseResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
-        TokenResponse tokenResponse = authService.login(request);
-        return BaseResponse.ok(tokenResponse);
+    public BaseResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        LoginResponse loginResponse = authService.login(request);
+        return BaseResponse.ok(loginResponse);
     }
 
     @Operation(summary = "카카오 로그인", description = "역할을 전달받아 세션에 저장한 뒤 카카오 OAuth2 로그인 페이지로 리다이렉트합니다.")

--- a/src/main/java/ctrlS/totori/auth/dto/LoginResponse.java
+++ b/src/main/java/ctrlS/totori/auth/dto/LoginResponse.java
@@ -1,0 +1,13 @@
+package ctrlS.totori.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        String role,
+        Boolean hasConnected
+) {
+
+}

--- a/src/main/java/ctrlS/totori/auth/service/AuthService.java
+++ b/src/main/java/ctrlS/totori/auth/service/AuthService.java
@@ -1,10 +1,13 @@
 package ctrlS.totori.auth.service;
 
+import ctrlS.totori.auth.dto.LoginResponse;
+import ctrlS.totori.connect.repository.ParentChildRepository;
 import ctrlS.totori.global.exception.CustomException;
 import ctrlS.totori.global.exception.ErrorCode;
 import ctrlS.totori.member.entity.LoginType;
 import ctrlS.totori.member.entity.Member;
 import ctrlS.totori.member.entity.MemberStat;
+import ctrlS.totori.member.entity.Role;
 import ctrlS.totori.member.repository.MemberRepository;
 import ctrlS.totori.auth.dto.LoginRequest;
 import ctrlS.totori.auth.dto.SignUpRequest;
@@ -24,6 +27,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthRedisService authRedisService;
+    private final ParentChildRepository parentChildRepository;
 
     @Transactional
     public void signUp(SignUpRequest request) {
@@ -50,7 +54,7 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public TokenResponse login(LoginRequest request) {
+    public LoginResponse login(LoginRequest request) {
         // DB에서 아이디로 회원 찾기
         Member member = memberRepository.findByLoginId(request.getLoginId())
                 .orElseThrow(() -> new CustomException(ErrorCode.LOGIN_ID_NOT_FOUND));
@@ -69,8 +73,13 @@ public class AuthService {
 
         authRedisService.saveRefreshToken(member.getId(), refreshToken);
 
+        Boolean hasConnected = null;
+        if (member.getRole() == Role.PARENT) {
+            hasConnected = parentChildRepository.existsByParent_Id(member.getId());
+        }
+
         // 토큰과 권한 정보 반환
-        return new TokenResponse(accessToken, refreshToken, role);
+        return new LoginResponse(accessToken, refreshToken, role, hasConnected);
     }
 
     public void logout(String bearerToken) {

--- a/src/main/java/ctrlS/totori/connect/repository/ParentChildRepository.java
+++ b/src/main/java/ctrlS/totori/connect/repository/ParentChildRepository.java
@@ -9,11 +9,13 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ParentChildRepository extends JpaRepository<ParentChild, Long> {
-
     boolean existsByParentAndChild(Member parent, Member child);
+    boolean existsByParent_Id(Long parentId);
     void deleteByParentId(Long parentId);
     void deleteByChildId(Long childId);
 
     @Query("SELECT pc.child FROM ParentChild pc WHERE pc.parent.id = :parentId")
     List<Member> findChildrenByParentId(@Param("parentId") Long parentId);
+
+
 }


### PR DESCRIPTION
## 🐣 작업 개요
> 구현한 기능을 요약하여 정리합니다.
- 보호자 로그인 시 아동 연결 여부 확인 로직 추가했습니다.

## 📍 변경 사항
Create: LoginResponse
Update: AuthController, AuthService, ParentChildRepository
  

## 🔍 참고 사항
보호자 로그인의 경우 `hasConnected` 필드가 추가되었습니다.
<img width="662" height="656" alt="스크린샷 2026-05-17 오전 2 29 21" src="https://github.com/user-attachments/assets/68b0f22b-a707-4bf4-aa90-f9523518eaee" />

아동 로그인의 경우 기존의 응답 방식과 동일합니다. 아동 로그인에도 `hasConnected` 필드가 필요하다면 추가하겠습니다.
<img width="657" height="632" alt="스크린샷 2026-05-17 오전 2 28 33" src="https://github.com/user-attachments/assets/044d8404-de20-4977-a7b0-39c00d5817c5" />


## ✨ 관련 이슈
- closes #104 

## 🔧 변경 유형
* [x] Bug Fix (fix)
* [x] New Features (feat)
* [ ] Test (test)
* [ ] Document modification (docs)
* [x] Refactoring (refactor)
* [ ] Styling (style)
* [ ] ETC, No production code change (chore)
* [ ] Build task and Dependency management (build)
---
